### PR TITLE
Fixed routing for settings not obeying base config settings.

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 
 An interface for the administrator to easily change application settings. Uses Laravel Backpack. On Laravel 5.2.
 
-**Subscribe to the [Backpack Newsletter](http://eepurl.com/bUEGjf) to be announced of any breaking changes or major updates (frequency: monthly or less).** 
+**Subscribe to the [Backpack Newsletter](http://eepurl.com/bUEGjf) to be announced of any breaking changes or major updates (frequency: monthly or less).**
 
 ## Install
 
@@ -35,7 +35,7 @@ $ php artisan db:seed --class="Backpack\Settings\database\seeds\SettingsTableSee
 4) [Optional] Add a menu item for it in resources/views/vendor/backpack/base/inc/sidebar.blade.php or menu.blade.php:
 
 ```html
-<li><a href="{{ url('admin/setting') }}"><i class="fa fa-cog"></i> <span>Settings</span></a></li>
+<li><a href="{{ url(config('backpack.base.route_prefix', 'admin') . '/setting') }}"><i class="fa fa-cog"></i> <span>Settings</span></a></li>
 ```
 
 ## Usage

--- a/src/SettingsServiceProvider.php
+++ b/src/SettingsServiceProvider.php
@@ -53,10 +53,11 @@ class SettingsServiceProvider extends ServiceProvider
     {
         $router->group(['namespace' => 'Backpack\Settings\app\Http\Controllers'], function ($router) {
             // Admin Interface Routes
-            Route::group(['prefix' => 'admin', 'middleware' => ['web', 'admin']], function () {
-                // Settings
-                Route::resource('setting', 'SettingCrudController');
-            });
+            Route::group(['prefix' => config('backpack.base.route_prefix', 'admin'),
+                        'middleware' => ['web', 'admin']], function () {
+                            // Settings
+                            Route::resource('setting', 'SettingCrudController');
+                        });
         });
     }
 

--- a/src/app/Http/Controllers/SettingCrudController.php
+++ b/src/app/Http/Controllers/SettingCrudController.php
@@ -15,7 +15,7 @@ class SettingCrudController extends CrudController
 
         $this->crud->setModel("Backpack\Settings\app\Models\Setting");
         $this->crud->setEntityNameStrings('setting', 'settings');
-        $this->crud->setRoute('admin/setting');
+        $this->crud->setRoute(config('backpack.base.route_prefix', 'admin') . '/setting');
         $this->crud->denyAccess(['create', 'delete']);
         $this->crud->setColumns(['name', 'value', 'description']);
         $this->crud->addField([


### PR DESCRIPTION
Fixes #10 
If `route_prefix` is changed in the `backpack.base` config file, the change will now be respected by settings.