### PR TITLE
Refactor to prevent eager db load

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,11 +21,13 @@ An interface for the administrator to easily change application settings. Uses L
 $ composer require backpack/settings
 ```
 
-2) Add the service provider to your config/app.php file:
+2) Add the service provider and facade to your config/app.php file:
 ```php
 Backpack\Settings\SettingsServiceProvider::class,
 ```
-
+```php
+'Settings' => Backpack\Settings\app\Facades\SettingsFacade::class,
+```
 3) Run the migration and add some example settings:
 ```bash
 $ php artisan vendor:publish --provider="Backpack\Settings\SettingsServiceProvider"
@@ -48,7 +50,7 @@ Add it to the menu or access it by its route: **application/admin/setting**
 Use it like you would any config value in a virtual settings.php file. Except the values are stored in the database and fetched on boot, instead of being stored in a file.
 
 ``` php
-Config::get('settings.contact_email')
+Settings::get('contact_email')
 ```
 
 ### Add new settings

--- a/src/app/Facades/SettingsFacade.php
+++ b/src/app/Facades/SettingsFacade.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Backpack\Settings\app\Facades;
+
+use Illuminate\Support\Facades\Facade;
+
+class SettingsFacade extends Facade
+{
+    protected static function getFacadeAccessor()
+    {
+        return 'settings';
+    }
+}

--- a/src/database/migrations/2016_12_01_142854_update_settings_table.php
+++ b/src/database/migrations/2016_12_01_142854_update_settings_table.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Migrations\Migration;
+
+class UpdateSettingsTable extends Migration // @codingStandardsIgnoreLine
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('settings', function (Blueprint $table) {
+            $table->text('value')->nullable()->change();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('settings', function (Blueprint $table) {
+            $table->string('value')->nullable()->change();
+        });
+    }
+}


### PR DESCRIPTION
The current setup always fetches data from the database on every request. This is not necessary and also causes problems when trying to `composer install` without a db connection – which is something you might do if you (like me) are building docker images of your app.