### PR TITLE
[Bug Fix] Prevents DB Queries running when Artisan is running commands

### DIFF
--- a/src/SettingsServiceProvider.php
+++ b/src/SettingsServiceProvider.php
@@ -25,21 +25,23 @@ class SettingsServiceProvider extends ServiceProvider
      */
     public function boot()
     {
-        // only use the Settings package if the Settings table is present in the database
-        if (count(Schema::getColumnListing('settings'))) {
-            // get all settings from the database
-            $settings = Setting::all();
+        if (! \App::runningInConsole()) {
+            // only use the Settings package if the Settings table is present in the database
+            if (count(Schema::getColumnListing('settings'))) {
+                // get all settings from the database
+                $settings = Setting::all();
 
-            // bind all settings to the Laravel config, so you can call them like
-            // Config::get('settings.contact_email')
-            foreach ($settings as $key => $setting) {
-                Config::set('settings.'.$setting->key, $setting->value);
+                // bind all settings to the Laravel config, so you can call them like
+                // Config::get('settings.contact_email')
+                foreach ($settings as $key => $setting) {
+                    Config::set('settings.'.$setting->key, $setting->value);
+                }
             }
-        }
 
-        // publish the migrations and seeds
-        $this->publishes([__DIR__.'/database/migrations/' => database_path('migrations')], 'migrations');
-        $this->publishes([__DIR__.'/database/seeds/' => database_path('seeds')], 'seeds');
+            // publish the migrations and seeds
+            $this->publishes([__DIR__.'/database/migrations/' => database_path('migrations')], 'migrations');
+            $this->publishes([__DIR__.'/database/seeds/' => database_path('seeds')], 'seeds');
+        }
     }
 
     /**

--- a/src/SettingsServiceProvider.php
+++ b/src/SettingsServiceProvider.php
@@ -25,7 +25,7 @@ class SettingsServiceProvider extends ServiceProvider
      */
     public function boot()
     {
-        if (! \App::runningInConsole()) {
+        if (!\App::runningInConsole()) {
             // only use the Settings package if the Settings table is present in the database
             if (count(Schema::getColumnListing('settings'))) {
                 // get all settings from the database


### PR DESCRIPTION
Running the DB queries clashes with artisan cli when no database is available.

Meaning you cannot install/run artisan without setting up a database which makes deploying with systems like Envoyer, Codeship, Deploybot impossible.