### PR TITLE
Add translation from lang files and Lao translation

### DIFF
--- a/src/SettingsServiceProvider.php
+++ b/src/SettingsServiceProvider.php
@@ -37,9 +37,14 @@ class SettingsServiceProvider extends ServiceProvider
             }
         }
 
+        $this->loadTranslationsFrom(realpath(__DIR__.'/resources/lang'), 'backpack');
+
         // publish the migrations and seeds
         $this->publishes([__DIR__.'/database/migrations/' => database_path('migrations')], 'migrations');
         $this->publishes([__DIR__.'/database/seeds/' => database_path('seeds')], 'seeds');
+
+        // publish translation files
+        $this->publishes([__DIR__.'/resources/lang' => resource_path('lang/vendor/backpack')], 'lang');
     }
 
     /**

--- a/src/app/Http/Controllers/SettingCrudController.php
+++ b/src/app/Http/Controllers/SettingCrudController.php
@@ -14,18 +14,31 @@ class SettingCrudController extends CrudController
         parent::__construct();
 
         $this->crud->setModel("Backpack\Settings\app\Models\Setting");
-        $this->crud->setEntityNameStrings('setting', 'settings');
+        $this->crud->setEntityNameStrings(trans('backpack::settings.setting_singular'), trans('backpack::settings.setting_plural'));
         $this->crud->setRoute(config('backpack.base.route_prefix', 'admin').'/setting');
         $this->crud->denyAccess(['create', 'delete']);
-        $this->crud->setColumns(['name', 'value', 'description']);
+        $this->crud->setColumns([
+            [
+                'name' => 'name',
+                'label' => trans('backpack::settings.name'),
+            ],
+            [
+                'name' => 'value',
+                'label' => trans('backpack::settings.value'),
+            ],
+            [
+                'name' => 'description',
+                'label' => trans('backpack::settings.description'),
+            ],
+        ]);
         $this->crud->addField([
-                                'name'       => 'name',
-                                'label'      => 'Name',
-                                'type'       => 'text',
-                                'attributes' => [
-                                    'disabled' => 'disabled',
-                                    ],
-                            ]);
+            'name'       => 'name',
+            'label'      => trans('backpack::settings.name'),
+            'type'       => 'text',
+            'attributes' => [
+                'disabled' => 'disabled',
+            ],
+        ]);
     }
 
     /**

--- a/src/app/Http/Controllers/SettingCrudController.php
+++ b/src/app/Http/Controllers/SettingCrudController.php
@@ -19,15 +19,15 @@ class SettingCrudController extends CrudController
         $this->crud->denyAccess(['create', 'delete']);
         $this->crud->setColumns([
             [
-                'name' => 'name',
+                'name'  => 'name',
                 'label' => trans('backpack::settings.name'),
             ],
             [
-                'name' => 'value',
+                'name'  => 'value',
                 'label' => trans('backpack::settings.value'),
             ],
             [
-                'name' => 'description',
+                'name'  => 'description',
                 'label' => trans('backpack::settings.description'),
             ],
         ]);

--- a/src/resources/lang/en/settings.php
+++ b/src/resources/lang/en/settings.php
@@ -1,0 +1,18 @@
+<?php
+
+return [
+  /*
+  |--------------------------------------------------------------------------
+  | Settings Language Lines
+  |--------------------------------------------------------------------------
+  |
+  | The following language lines are used for Laravel Backpack - Settings
+  |
+  */
+  'name'               => 'Name',
+  'value'              => 'Value',
+  'description'        => 'Description',  
+  'setting_singular'   => 'setting',
+  'setting_plural'     => 'settings',
+
+];

--- a/src/resources/lang/en/settings.php
+++ b/src/resources/lang/en/settings.php
@@ -11,7 +11,7 @@ return [
   */
   'name'               => 'Name',
   'value'              => 'Value',
-  'description'        => 'Description',  
+  'description'        => 'Description',
   'setting_singular'   => 'setting',
   'setting_plural'     => 'settings',
 

--- a/src/resources/lang/lo/settings.php
+++ b/src/resources/lang/lo/settings.php
@@ -11,7 +11,7 @@ return [
   */
   'name'               => 'ຊື່',
   'value'              => 'ຄ່າທີ່ລະບຸ',
-  'description'        => 'ຄໍາອະທິບາຍ',  
+  'description'        => 'ຄໍາອະທິບາຍ',
   'setting_singular'   => 'ການຕັ້ງຄ່າ',
   'setting_plural'     => 'ການຕັ້ງຄ່າຕ່າງໆ',
 

--- a/src/resources/lang/lo/settings.php
+++ b/src/resources/lang/lo/settings.php
@@ -1,0 +1,18 @@
+<?php
+
+return [
+  /*
+  |--------------------------------------------------------------------------
+  | Settings Language Lines
+  |--------------------------------------------------------------------------
+  |
+  | The following language lines are used for Laravel Backpack - Settings
+  |
+  */
+  'name'               => 'ຊື່',
+  'value'              => 'ຄ່າທີ່ລະບຸ',
+  'description'        => 'ຄໍາອະທິບາຍ',  
+  'setting_singular'   => 'ການຕັ້ງຄ່າ',
+  'setting_plural'     => 'ການຕັ້ງຄ່າຕ່າງໆ',
+
+];


### PR DESCRIPTION
1. Load translation from lang files rather than hard-code string.
2. Add Lao (lo) translation.

Publish lang file using:
`php artisan vendor:publish --provider="Backpack\Settings\SettingsServiceProvider" --tag=lang`