### PR TITLE
Fix Number Field attributes problem #33

### DIFF
--- a/src/app/Http/Controllers/SettingCrudController.php
+++ b/src/app/Http/Controllers/SettingCrudController.php
@@ -72,7 +72,7 @@ class SettingCrudController extends CrudController
         $this->crud->hasAccessOrFail('update');
 
         $this->data['entry'] = $this->crud->getEntry($id);
-        $this->crud->addField((array) json_decode($this->data['entry']->field)); // <---- this is where it's different
+        $this->crud->addField(json_decode($this->data['entry']->field, true)); // <---- this is where it's different
         $this->data['crud'] = $this->crud;
         $this->data['saveAction'] = $this->getSaveAction();
         $this->data['fields'] = $this->crud->getUpdateFields($id);

--- a/src/app/Http/Controllers/SettingCrudController.php
+++ b/src/app/Http/Controllers/SettingCrudController.php
@@ -72,7 +72,7 @@ class SettingCrudController extends CrudController
         $this->crud->hasAccessOrFail('update');
 
         $this->data['entry'] = $this->crud->getEntry($id);
-        $this->crud->addField(json_decode($this->data['entry']->field, true)); // <---- this is where it's different
+        $this->crud->addField(json_decode($this->data['entry']->field, true));
         $this->data['crud'] = $this->crud;
         $this->data['saveAction'] = $this->getSaveAction();
         $this->data['fields'] = $this->crud->getUpdateFields($id);


### PR DESCRIPTION
Returned objects should be fully (deeply) converted into associative arrays. Not just the "first level" of object when using (array) casting.