### PR TITLE
value field as text

### DIFF
--- a/src/database/migrations/2015_08_04_131614_create_settings_table.php
+++ b/src/database/migrations/2015_08_04_131614_create_settings_table.php
@@ -17,7 +17,7 @@ class CreateSettingsTable extends Migration
             $table->string('key');
             $table->string('name');
             $table->string('description')->nullable();
-            $table->string('value')->nullable();
+            $table->text('value')->nullable();
             $table->text('field');
             $table->tinyInteger('active');
             $table->timestamps();


### PR DESCRIPTION
Otherwise, textarea truncates values

## Problem Example
Make a setting to store google analytics code in header

like this:

	<script>
	(function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
	(i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
	m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
	})(window,document,'script','https://www.google-analytics.com/analytics.js','ga');

	ga('create', 'UA-XXXX-XX', 'auto');
	ga('send', 'pageview');

	</script>

You make your setting with textarea:

	DB::table('settings')->insert([
	    'key'           => 'scripts_header',
	    'name'          => 'scripts header',
	    'description'   => 'this in header',
	    'value'         => '',
	    'field'         => '{"name":"value","label":"Value","type":"textarea"}',
	    'active'        => 1,
	]);

Result in something like this:

	<script>
	(function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
	(i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
	m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
	})(window,document,'script','https://www.google-analytics.com/analytics.js','ga');

	ga('create', 'UA-XXXX-X='(