### PR TITLE
Fix 'Class CRUD not found' bug

### DIFF
--- a/src/SettingsServiceProvider.php
+++ b/src/SettingsServiceProvider.php
@@ -32,6 +32,9 @@ class SettingsServiceProvider extends ServiceProvider
      */
     public function boot()
     {
+        // define the routes for the application
+        $this->setupRoutes($this->app->router);
+
         // only use the Settings package if the Settings table is present in the database
         if (!\App::runningInConsole() && count(Schema::getColumnListing('settings'))) {
             // get all settings from the database
@@ -78,8 +81,6 @@ class SettingsServiceProvider extends ServiceProvider
     public function register()
     {
         $this->registerSettings();
-
-        $this->setupRoutes($this->app->router);
     }
 
     private function registerSettings()


### PR DESCRIPTION
Fix #64

Like i said, Laravel documentation mentions this:

> You should never attempt to register any event listeners, routes, or any other piece of functionality within the register method. Otherwise, you may accidentally use a service that is provided by a service provider which has not loaded yet.

https://laravel.com/docs/5.5/providers