### PR TITLE
Add settings easily from admin panel with improvements to handle upload image field

### DIFF
--- a/src/SettingsServiceProvider.php
+++ b/src/SettingsServiceProvider.php
@@ -51,6 +51,14 @@ class SettingsServiceProvider extends ServiceProvider
 
         // publish translation files
         $this->publishes([__DIR__.'/resources/lang' => resource_path('lang/vendor/backpack')], 'lang');
+
+        // use the vendor configuration file as fallback
+        $this->mergeConfigFrom(
+            __DIR__.'/config/backpack/settings.php',
+            'backpack.settings'
+        );
+        // publish config file
+        $this->publishes([__DIR__.'/config' => config_path()], 'config');
     }
 
     /**

--- a/src/app/Http/Controllers/SettingCrudController.php
+++ b/src/app/Http/Controllers/SettingCrudController.php
@@ -11,7 +11,7 @@ class SettingCrudController extends CrudController
 {
     public function setup()
     {
-        $this->crud->setModel("\App\Models\Setting");
+        $this->crud->setModel("Backpack\Settings\app\Models\Setting");
         $this->crud->setEntityNameStrings(trans('backpack::settings.setting_singular'), trans('backpack::settings.setting_plural'));
         $this->crud->setRoute(config('backpack.base.route_prefix', 'admin').'/setting');
         $this->crud->setColumns([

--- a/src/app/Http/Controllers/SettingCrudController.php
+++ b/src/app/Http/Controllers/SettingCrudController.php
@@ -11,7 +11,7 @@ class SettingCrudController extends CrudController
 {
     public function setup()
     {
-        $this->crud->setModel("Backpack\Settings\app\Models\Setting");
+        $this->crud->setModel("\App\Models\Setting");
         $this->crud->setEntityNameStrings(trans('backpack::settings.setting_singular'), trans('backpack::settings.setting_plural'));
         $this->crud->setRoute(config('backpack.base.route_prefix', 'admin').'/setting');
         $this->crud->setColumns([
@@ -112,7 +112,7 @@ class SettingCrudController extends CrudController
         $this->crud->hasAccessOrFail('update');
 
         $this->data['entry'] = $this->crud->getEntry($id);
-        $this->crud->addField((array) json_decode($this->getFieldJsonValue(), true)); // <---- this is where it's different
+        $this->crud->addField((array) $this->getFieldJsonValue($id, $this->isImageField($id))); // <---- this is where it's different
         $this->data['crud'] = $this->crud;
         $this->data['saveAction'] = $this->getSaveAction();
         $this->data['fields'] = $this->crud->getUpdateFields($id);
@@ -138,10 +138,49 @@ class SettingCrudController extends CrudController
 
     /**
      * get the correct field json value to add the correct field to edit form
+     * @param int $id
+     * @param boolean $isImage
+     * @return array
+     */
+    protected function getFieldJsonValue($id, $isImage = true) {
+        $fieldValue = $this->crud->getEntry($id)->field;
+
+        $fieldJson = [];
+
+        if ($isImage == false) {
+
+            $fieldJson['name'] = "value";
+            $fieldJson['label'] = "Value";
+            $fieldJson['type'] = $fieldValue;
+
+            return $fieldJson;
+        } else {
+
+            $fieldJson['name'] = "value";
+            $fieldJson['label'] = "Value";
+            $fieldJson['type'] = $fieldValue;
+            $fieldJson['upload'] = config('backpack.settings.image_upload_enabled');
+            $fieldJson['crop'] = config('backpack.settings.image_crop_enabled');
+            $fieldJson['aspect_ratio'] = config('backpack.settings.image_aspect_ratio');
+            $fieldJson['prefix'] = config('backpack.settings.image_prefix');
+            return $fieldJson;
+        }
+
+    }
+    /**
+     * get the correct field type
+     * @param int $id
      * @return string
      */
-    protected function getFieldJsonValue() {
-        $fieldValue = $this->data['entry']->field;
-        return "{\"name\":\"value\",\"label\":\"Value\",\"type\":\"$fieldValue\"}";
+    protected function getFieldType($id) {
+        return $this->crud->getEntry($id)->field;
+    }
+    /**
+     * get the correct field type
+     * @param int $id
+     * @return boolean
+     */
+    protected function isImageField($id) {
+        return $this->getFieldType($id) == "image" ? true : false;
     }
 }

--- a/src/app/Models/Setting.php
+++ b/src/app/Models/Setting.php
@@ -4,11 +4,180 @@ namespace Backpack\Settings\app\Models;
 
 use Backpack\CRUD\CrudTrait;
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Storage;
+use Intervention\Image\Facades\Image;
+use Prologue\Alerts\Facades\Alert;
 
 class Setting extends Model
 {
     use CrudTrait;
 
     protected $table = 'settings';
-    protected $fillable = ['value'];
+    protected $fillable = ['name', 'key', 'value', 'field', 'description', 'active'];
+
+    /**
+     * Model Boot function
+     * Need it to delete image file from disk if the field type == image
+     */
+    public static function boot()
+    {
+        parent::boot();
+        static::deleting(function($obj) {
+            // 1. decode field object
+            $fieldDecoded = json_decode($obj->field, true);
+            // 2. get field type
+            $type = $fieldDecoded['type'];
+            // 3. check if it's image
+            if ($type == "image") {
+                // 4. delete from disk
+                if (!Storage::disk(config('backpack.settings.images_disk_name'))->delete($obj->value)) {
+                    // filed to delete image file
+                    Alert::error(trans('backpack::settings.delete_image_file_not_message'))->flash();
+                }
+            }
+        });
+    }
+    /**
+     * set field json to database
+     * @param $field
+     */
+    public function setFieldAttribute($field)
+    {
+        $filedJson = "{\"name\":\"value\",\"label\":\"Value\",\"type\":\"$field\"}";
+        $this->attributes['field'] = $filedJson;
+    }
+    /**
+     * get the correct type value for select2_from_array
+     * @param $field
+     * @return string
+     */
+    public function getFieldAttribute($field)
+    {
+        $fieldDecoded = json_decode($field, true);
+        return $fieldDecoded['type'];
+    }
+    /**
+     * set the correct value and check if image field
+     * @param $value
+     */
+    public function setValueAttribute($value)
+    {
+        // get item id
+        $id = $this->id;
+        // get setting object from database
+        $setting = DB::table($this->table)->where('id', $id)->first();
+        // decode field object
+        $fieldDecoded = json_decode($setting->field, true);
+        // get field type
+        $type = $fieldDecoded['type'];
+
+        // column attribute name
+        $attribute_name = "value";
+        // get images disk
+        $disk = config('backpack.settings.images_disk_name');
+        // get destination folder
+        $destination_path = config('backpack.settings.images_folder');
+
+        switch ($type) {
+            case 'image':
+                // if the image was erased
+                if (is_null($value)) {
+                    // delete the image from disk
+                    if (Storage::disk($disk)->delete($this->{$attribute_name})) {
+                        // set null in the database after the successful delete
+                        $this->attributes[$attribute_name] = null;
+                    }
+                }
+
+                // if a base64 was sent, store it in the db
+                if (starts_with($value, 'data:image'))
+                {
+                    // 0. Get image extension
+                    preg_match("/^data:image\/(.*);base64/i",$value, $match);
+                    $extension = $match[1];
+                    // 1. Make the image
+                    $image = Image::make($value);
+                    if (!is_null($image)) {
+                        // 2. Generate a filename.
+                        $filename = md5($value.time()).'.'.$extension;
+                        try {
+                            // 3. Store the image on disk.
+                            Storage::disk($disk)->put($destination_path.'/'.$filename, $image->stream());
+                            // 4. Save the path to the database
+                            $this->attributes[$attribute_name] = $destination_path.'/'.$filename;
+                        } catch (\InvalidArgumentException $argumentException) {
+                            // 3. failed to save file
+                            Alert::error($argumentException->getMessage())->flash();
+                            // 4. set as null when fail to save the image to disk
+                            $this->attributes[$attribute_name] = null;
+                        }
+                    }
+
+                }
+                break;
+            default:
+                $this->attributes[$attribute_name] = $value;
+                break;
+        }
+    }
+    /**
+     * get the correct value and check fields types
+     * and return the correct tags
+     * @return mixed
+     */
+    public function getValueFunction()
+    {
+        $attribute_name = 'value';
+
+        // get item id
+        $id = $this->id;
+        // get setting object from database
+        $setting = DB::table($this->table)->where('id', $id)->first();
+        // decode field object
+        $fieldDecoded = json_decode($setting->field, true);
+        // get field type
+        $type = $fieldDecoded['type'];
+        // check value set
+        if (!isset($setting->{$attribute_name})) return false;
+        // get value
+        $value = $setting->{$attribute_name};
+
+        switch ($type) {
+            case 'text':
+                return str_limit(strip_tags($value), 80, "[...]");
+                break;
+            case 'url':
+                return '<a href="'.$value.'">'.$value.'</a>';
+                break;
+            case 'email':
+                return '<a href="mailto:'.$value.'" target="_top">'.$value.'</a>';
+                break;
+            case 'checkbox':
+                if ($value == 1) {
+                    // if true return success label with YES string
+                    $html = '<span class="label label-success">YES</span>';
+                } else {
+                    // if false return danger label with NO string
+                    $html = '<span class="label label-danger">NO</span>';
+                }
+                return $html;
+                break;
+            case 'image':
+                return '<a href="'.url('/uploads/'.$value).'"><img class="img-circle" width="70px" height="70px" src="'.url('/uploads/'.$value).'" alt="User Avatar"></a>';
+                break;
+            case 'password':
+                return '<a class="btn btn-default"><i class="fa fa-key"></i></a>';
+                break;
+            case 'number':
+                return $value;
+                break;
+            case 'icon_picker':
+                return '<a class="btn btn-default"><i class="fa '.$value.'"></i></a>';
+                break;
+            default:
+                return $type;
+                break;
+        }
+    }
 }

--- a/src/app/Models/Setting.php
+++ b/src/app/Models/Setting.php
@@ -9,6 +9,10 @@ use Illuminate\Support\Facades\Storage;
 use Intervention\Image\Facades\Image;
 use Prologue\Alerts\Facades\Alert;
 
+/**
+ * Class Setting
+ * @package App\Models
+ */
 class Setting extends Model
 {
     use CrudTrait;
@@ -44,8 +48,12 @@ class Setting extends Model
      */
     public function setFieldAttribute($field)
     {
-        $filedJson = "{\"name\":\"value\",\"label\":\"Value\",\"type\":\"$field\"}";
-        $this->attributes['field'] = $filedJson;
+        $fieldJson = [];
+        $fieldJson['name'] = "value";
+        $fieldJson['label'] = "Value";
+        $fieldJson['type'] = $field;
+
+        $this->attributes['field'] = json_encode($fieldJson);
     }
     /**
      * get the correct type value for select2_from_array
@@ -164,7 +172,7 @@ class Setting extends Model
                 return $html;
                 break;
             case 'image':
-                return '<a href="'.url('/uploads/'.$value).'"><img class="img-circle" width="70px" height="70px" src="'.url('/uploads/'.$value).'" alt="User Avatar"></a>';
+                return '<a href="'.url(config('backpack.settings.image_prefix').$value).'"><img class="img-circle" width="70px" height="70px" src="'.url('/uploads/'.$value).'" alt="User Avatar"></a>';
                 break;
             case 'password':
                 return '<a class="btn btn-default"><i class="fa fa-key"></i></a>';

--- a/src/config/backpack/settings.php
+++ b/src/config/backpack/settings.php
@@ -1,0 +1,9 @@
+<?php
+
+return [
+    // Settings configuration file
+    // you can customize the disk name where you need save image ( if you use image field type )
+    // and customize other configurations needed by the package
+    'images_disk_name' => 'public',
+    'images_folder' => 'images',
+];

--- a/src/config/backpack/settings.php
+++ b/src/config/backpack/settings.php
@@ -4,6 +4,11 @@ return [
     // Settings configuration file
     // you can customize the disk name where you need save image ( if you use image field type )
     // and customize other configurations needed by the package
-    'images_disk_name' => 'public',
-    'images_folder' => 'images',
+
+    'images_disk_name' => 'uploads', // disk where images will be saved
+    'images_folder' => 'images', // folder where images will be saved inside it in the specified disk
+    'image_upload_enabled' => true, // set to true to allow uploading, false to disable
+    'image_crop_enabled' => true, // set to true to allow cropping, false to disable
+    'image_aspect_ratio' => 1, // ommit or set to 0 to allow any aspect ratio
+    'image_prefix' => 'uploads/',  // in case you only store the filename in the database, this text will be prepended to the database value
 ];

--- a/src/database/migrations/2015_08_04_131614_create_settings_table.php
+++ b/src/database/migrations/2015_08_04_131614_create_settings_table.php
@@ -19,7 +19,7 @@ class CreateSettingsTable extends Migration
             $table->string('description')->nullable();
             $table->text('value')->nullable();
             $table->text('field');
-            $table->tinyInteger('active');
+            $table->tinyInteger('active')->default(1);
             $table->timestamps();
         });
     }

--- a/src/resources/lang/en/settings.php
+++ b/src/resources/lang/en/settings.php
@@ -11,8 +11,13 @@ return [
     */
     'name'             => 'Name',
     'value'            => 'Value',
+    'key'              => 'Key',
+    'select_field'     => 'Select field type',
+    'active'           => 'is Active',
     'description'      => 'Description',
     'setting_singular' => 'setting',
     'setting_plural'   => 'settings',
+    'delete_image_file_not_message'    => "There's been an error. Your image might not have been deleted from the disk.",
+
 
 ];


### PR DESCRIPTION
i have been thinking about this pull request from the first time i used this package but i hadn't really time to do it but now it's done i hope it will be useful and improve the usage of this awesome package 

How to use 
1. admin create the settings field he need and click save
![capture d ecran 2018-01-24 a 14 06 11](https://user-images.githubusercontent.com/1247248/35333671-ddd98a0a-010f-11e8-9d85-f70854c27648.png)

2. if he selected for example image field ( it will be empty inside the list page )
![capture d ecran 2018-01-24 a 14 06 17](https://user-images.githubusercontent.com/1247248/35333687-eb2ec7b0-010f-11e8-93de-0a79105c18f5.png)

3. admin now can click edit button and he will find the field he selected from the create page
![capture d ecran 2018-01-24 a 14 06 29](https://user-images.githubusercontent.com/1247248/35333703-ff75f36a-010f-11e8-9890-75a5e4101331.png)

4. now if it's image as we set before i have setup configurations for configure almost everything for image field and if cropper enabled etc the image will appear normally and use can save it 
![capture d ecran 2018-01-24 a 14 06 41](https://user-images.githubusercontent.com/1247248/35333721-1323d238-0110-11e8-9768-a6b3d80ea10f.png)

that's all and here's a list of supported field
```
[
 'text' => 'Text',
 'email' => 'Email',
 'checkbox' => 'Checkbox',
 'number' => 'Number',
 'url' => 'URL',
 'image' => 'Image',
 'password' => 'Password',
 'icon_picker' => 'Icon Picker',
]
```
and here's how it appears in list page
![capture d ecran 2018-01-24 a 13 59 39](https://user-images.githubusercontent.com/1247248/35333810-69c90ec8-0110-11e8-9336-8a3d5f0ac2d3.png)
