### PR TITLE
Fixed error with field attributes

### DIFF
--- a/src/app/Http/Controllers/SettingCrudController.php
+++ b/src/app/Http/Controllers/SettingCrudController.php
@@ -72,7 +72,7 @@ class SettingCrudController extends CrudController
         $this->crud->hasAccessOrFail('update');
 
         $this->data['entry'] = $this->crud->getEntry($id);
-        $this->crud->addField((array) json_decode($this->data['entry']->field)); // <---- this is where it's different
+        $this->crud->addField((json_decode($this->data['entry']->field, true)); // <---- this is where it's different
         $this->data['crud'] = $this->crud;
         $this->data['saveAction'] = $this->getSaveAction();
         $this->data['fields'] = $this->crud->getUpdateFields($id);

--- a/src/app/Http/Controllers/SettingCrudController.php
+++ b/src/app/Http/Controllers/SettingCrudController.php
@@ -72,7 +72,7 @@ class SettingCrudController extends CrudController
         $this->crud->hasAccessOrFail('update');
 
         $this->data['entry'] = $this->crud->getEntry($id);
-        $this->crud->addField((json_decode($this->data['entry']->field, true)); // <---- this is where it's different
+        $this->crud->addField(json_decode($this->data['entry']->field, true)); // <---- this is where it's different
         $this->data['crud'] = $this->crud;
         $this->data['saveAction'] = $this->getSaveAction();
         $this->data['fields'] = $this->crud->getUpdateFields($id);


### PR DESCRIPTION
Plain casting to an array does not convert nested arrays, which causes `attributes` parameter remained as stdClass by default. 

This PR fixes that behavior, making `attributes` an actual array that doesn't break edit page.