### PR TITLE
Alias, getter and setter

### DIFF
--- a/src/SettingsServiceProvider.php
+++ b/src/SettingsServiceProvider.php
@@ -80,13 +80,12 @@ class SettingsServiceProvider extends ServiceProvider
      */
     public function register()
     {
-        $this->registerSettings();
-    }
-
-    private function registerSettings()
-    {
         $this->app->bind('settings', function ($app) {
             return new Settings($app);
         });
+
+        // register their aliases
+        $loader = \Illuminate\Foundation\AliasLoader::getInstance();
+        $loader->alias('Setting', \Backpack\Settings\app\Models\Setting::class);
     }
 }

--- a/src/app/Models/Setting.php
+++ b/src/app/Models/Setting.php
@@ -11,4 +11,31 @@ class Setting extends Model
 
     protected $table = 'settings';
     protected $fillable = ['value'];
+
+    public static function get($key)
+    {
+    	$setting = new Setting;
+    	$entry = $setting->where('key', $key)->first();
+
+    	if (!$entry) {
+    		return null;
+    	}
+
+		return $entry->value;
+    }
+
+    public static function set($key, $value = null)
+    {
+    	$setting = new Setting;
+    	$entry = $setting->where('key', $key)->first();
+
+    	if (!$entry) {
+    		return false;
+    	}
+
+    	$entry->update(['value' => $value]);
+    	\Config::set('settings.'.$key, $value);
+
+    	return true;
+    }
 }

--- a/src/app/Models/Setting.php
+++ b/src/app/Models/Setting.php
@@ -14,28 +14,28 @@ class Setting extends Model
 
     public static function get($key)
     {
-    	$setting = new Setting;
-    	$entry = $setting->where('key', $key)->first();
+        $setting = new self();
+        $entry = $setting->where('key', $key)->first();
 
-    	if (!$entry) {
-    		return null;
-    	}
+        if (!$entry) {
+            return;
+        }
 
-		return $entry->value;
+        return $entry->value;
     }
 
     public static function set($key, $value = null)
     {
-    	$setting = new Setting;
-    	$entry = $setting->where('key', $key)->first();
+        $setting = new self();
+        $entry = $setting->where('key', $key)->first();
 
-    	if (!$entry) {
-    		return false;
-    	}
+        if (!$entry) {
+            return false;
+        }
 
-    	$entry->update(['value' => $value]);
-    	\Config::set('settings.'.$key, $value);
+        $entry->update(['value' => $value]);
+        \Config::set('settings.'.$key, $value);
 
-    	return true;
+        return true;
     }
 }


### PR DESCRIPTION
This PR allows us to use these anywhere inside the app (including Console):
```php
Setting::get('key_name'); // will get the value from db
Setting::set('key_name', 'value'); // will update the value in db and config variable 
```

Fixes #38 
Fixes #57 