### PR TITLE
replace 'admin' with backpack_middleware() helper

### DIFF
--- a/src/routes/backpack/settings.php
+++ b/src/routes/backpack/settings.php
@@ -13,7 +13,7 @@
 Route::group([
     'namespace'  => 'Backpack\Settings\app\Http\Controllers',
     'prefix'     => config('backpack.base.route_prefix', 'admin'),
-    'middleware' => ['web', 'admin'],
+    'middleware' => ['web', backpack_middleware()],
 ], function () {
     CRUD::resource('setting', 'SettingCrudController');
 });


### PR DESCRIPTION
Replace the 'admin' middleware call in routes/backpack/settings.php with the backpack_middleware() helper.

This will resolve any exceptions thrown when the config/backpack/base.php middleware name is anything other than 'admin'