### PR TITLE
Fix to use custom guard configured in Backpack base

### DIFF
--- a/src/app/Http/Requests/SettingRequest.php
+++ b/src/app/Http/Requests/SettingRequest.php
@@ -14,7 +14,7 @@ class SettingRequest extends FormRequest
     public function authorize()
     {
         // only allow updates if the user is logged in
-        return \Auth::check();
+        return backpack_auth()->check();
     }
 
     /**


### PR DESCRIPTION
Fixes issue #76. Allows use of custom guard.