### PR TITLE
Show a disabled setting->description field on edit

### DIFF
--- a/src/app/Http/Controllers/SettingCrudController.php
+++ b/src/app/Http/Controllers/SettingCrudController.php
@@ -49,6 +49,15 @@ class SettingCrudController extends CrudController
                 'disabled' => 'disabled',
             ],
         ]);
+        
+        CRUD::addField([
+            'name'       => 'description',
+            'label'      => trans('backpack::settings.description'),
+            'type'       => 'textarea',
+            'attributes' => [
+                'disabled' => 'disabled',
+            ],
+        ]);
 
         CRUD::addField(json_decode(CRUD::getCurrentEntry()->field, true));
     }


### PR DESCRIPTION
The setting->description describes what the setting does, but we are never able to see the full description in the admin panel.  We are able to see a truncated description in the index view of the settings i.e. "Email addresses separated by comma, to b[...]" but when we edit that setting, we don't see the description at all.  The description provides useful information on what the setting does and should be shown on the edit page as a disabled field, similar to the setting->name.  I made it a textarea instead of text in case the description is overly long.