### PR TITLE
Settings syncronization with config/settings.php

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,11 +25,14 @@ composer require backpack/settings
 php artisan vendor:publish --provider="Backpack\Settings\SettingsServiceProvider"
 php artisan migrate
 
+# change config/settings.php dummy settings
+
+# sync your settings to database
+php artisan settings:sync
+
 # [optional] add a menu item for it to the sidebar_content file
 php artisan backpack:add-sidebar-content "<li class='nav-item'><a class='nav-link' href='{{ backpack_url('setting') }}'><i class='nav-icon la la-cog'></i> <span>Settings</span></a></li>"
 
-# [optional] insert some example dummy data to the database
-php artisan db:seed --class="Backpack\Settings\database\seeds\SettingsTableSeeder"
 ```
 
 ## Usage
@@ -46,20 +49,17 @@ Setting::get('contact_email')
 Config::get('settings.contact_email')
 ```
 
-### Add new settings
+### Change settings
 
-Settings are stored in the database in the "settings" table. Its columns are:
-- id (ex: 1)
-- key (ex: contact_email)
-- name (ex: Contact form email address)
-- description (ex: The email address that all emails go to.)
-- value (ex: admin@laravelbackpack.com)
-- field (Backpack CRUD field configuration in JSON format. https://backpackforlaravel.com/docs/crud-fields#default-field-types)
-- active (1 or 0)
-- created_at
-- updated_at
+Available settings are stored in `config/settings.php`
 
-There is no interface available to add new settings. They are added by the developer directly in the database, since the Backpack CRUD field configuration is a bit complicated. See the field types and their configuration code on https://backpackforlaravel.com/docs
+To syncronize with database simply run: 
+
+```
+php artisan settings:sync
+```
+
+Note: this command doesn't overwrite 'value' column in database
 
 ### Override existing configurations
 

--- a/src/SettingsServiceProvider.php
+++ b/src/SettingsServiceProvider.php
@@ -2,6 +2,7 @@
 
 namespace Backpack\Settings;
 
+use Backpack\Settings\app\Console\Commands\SettingsSync;
 use Backpack\Settings\app\Models\Setting as Setting;
 use Config;
 use Illuminate\Routing\Router;
@@ -51,6 +52,14 @@ class SettingsServiceProvider extends ServiceProvider
 
         // publish translation files
         $this->publishes([__DIR__.'/resources/lang' => resource_path('lang/vendor/backpack')], 'lang');
+
+        // publish config/settings.php
+        $this->publishes([__DIR__.'/config/settings.php' => config_path('settings.php')], 'settings.php');
+
+        // register commands
+         $this->commands([ 
+           SettingsSync::class
+        ]);
     }
 
     /**

--- a/src/app/Console/Commands/SettingsSync.php
+++ b/src/app/Console/Commands/SettingsSync.php
@@ -1,0 +1,64 @@
+<?php
+
+namespace Backpack\Settings\app\Console\Commands;
+
+use Illuminate\Console\Command;
+use Backpack\Settings\app\Models\Setting;
+
+class SettingsSync extends Command
+{
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'settings:sync';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Syncs settings definitions with config/settings.php';
+
+    /**
+     * Create a new command instance.
+     *
+     * @return void
+     */
+    public function __construct()
+    {
+        parent::__construct();
+    }
+
+    /**
+     * Execute the console command.
+     *
+     * @return mixed
+     */
+    public function handle()
+    {
+        $settings = config('settings');
+        foreach ($settings as $index => $setting) {
+          // search for existing record
+            $record = Setting::where('key', $setting['key'])->first();
+            if ($record) {
+              // if exists, update all except value
+                $record->update([
+                'name' => $setting['name'],
+                'description' => $setting['description'],
+                'field' => $setting['field'],
+                'active' => $setting['active'],
+                ]);
+            } else {
+                Setting::insert($setting);
+            }
+        }
+
+        // purge settings not present in settings.php
+        Setting::whereNotIn('key', collect($settings)->pluck('key')->all())
+          ->delete();
+
+        $this->info("Settings updated");
+    }
+}

--- a/src/config/settings.php
+++ b/src/config/settings.php
@@ -1,0 +1,37 @@
+<?php
+return [
+  [
+    'key' => 'contact_email',
+    'name' => 'Contact form email address',
+    'description' => 'The email address that all emails from the contact form will go to.',
+    'value' => 'admin@updivision.com',
+    'field' => '{"name":"value", "label":"Value", "type":"email"}',
+    'active' => 1,
+  ],
+  [
+    'key' => 'contact_cc',
+    'name' => 'Contact form CC field',
+    'description' => 'Email addresses separated by comma, to be included as CC in the email sent by the contact form.',
+    'value' => '',
+    'field' => '{"name":"value", "label":"Value", "type":"text"}',
+    'active' => 1,
+
+  ],
+  [
+    'key' => 'contact_bcc',
+    'name' => 'Contact form BCC field',
+    'description' => 'Email addresses separated by comma, to be included as BCC in the email sent by the contact form.',
+    'value' => '',
+    'field' => '{"name":"value", "label":"Value", "type":"email"}',
+    'active' => 1,
+  ],
+  [
+    'key' => 'motto',
+    'name' => 'Motto',
+    'description' => 'Website motto',
+    'value' => 'this is the value',
+    'field' => '{"name":"value", "label":"Value", "type":"textarea"}',
+    'active' => 1,
+
+  ],
+];


### PR DESCRIPTION
Settings syncronization with config/settings.php
------------------------------------------------

Command settings:sync helps you keep production settings in sync with
config/settings.php
It doesn't override "value" field

Package now publishes config/settings.php

Backwards compatiblity
-----------------

What could go wrong? 

If user upgrades to this version, then doesn't have any config/settings.php file and runs `php artisan settings:sync` it'll use dummy settings in the package, removing user settings in their database. 

This is not a likely scenario of a cautious programmer running any command in production, but it'll be a good security check to have. 
(I'm not sure how to check for config/settings.php in user code only)