### PR TITLE
Add Vietnamese translation

### DIFF
--- a/src/resources/lang/vi/settings.php
+++ b/src/resources/lang/vi/settings.php
@@ -1,0 +1,18 @@
+<?php
+
+return [
+    /*
+    |--------------------------------------------------------------------------
+    | Settings Language Lines
+    |--------------------------------------------------------------------------
+    |
+    | The following language lines are used for Laravel Backpack - Settings
+    |
+    */
+    'name'             => 'Tên',
+    'value'            => 'Giá trị',
+    'description'      => 'Mô tả',
+    'setting_singular' => 'cấu hình',
+    'setting_plural'   => 'các cấu hình',
+
+];


### PR DESCRIPTION
## WHY

Add Vietnamese (vi) translation for Backpack Settings.

### BEFORE - What was wrong? What was happening before this PR?

Nothing was wrong

### AFTER - What is happening after this PR?

Backpack Settings will support Vietnamese (vi) language

## HOW

### How did you achieve that, in technical terms?

Change `locale` config in `config/app.php` file to use Vietnamese translation.

### Is it a breaking change or non-breaking change?

It's a non-breaking change.

### How can we test the before & after?

Change app's locale config to "vi" to see the changes.