### PR TITLE
Always overwrite Field name attribute to Value

### DIFF
--- a/src/app/Http/Controllers/SettingCrudController.php
+++ b/src/app/Http/Controllers/SettingCrudController.php
@@ -49,7 +49,8 @@ class SettingCrudController extends CrudController
                 'disabled' => 'disabled',
             ],
         ]);
-
-        CRUD::addField(json_decode(CRUD::getCurrentEntry()->field, true));
+        $field = json_decode(CRUD::getCurrentEntry()->field, true);
+        $field['name'] = 'value';
+        CRUD::addField($field);
     }
 }


### PR DESCRIPTION
## WHY

In documentation it says: 
**field (Backpack CRUD field configuration in JSON format. https://backpackforlaravel.com/docs/crud-fields#default-field-types)**

As new to backpack, I lost an hour trying to figure it out Why my settings weren't working while I was setting **field name** to title or logo or whatever.

### BEFORE - What was wrong? What was happening before this PR?

If somebody writes field name to something else than value, the update operation isn't working.

### AFTER - What is happening after this PR?

We make sure always field name is set to **value**


### How did you achieve that, in technical terms?

Always overwriting $field['name'] = 'value'; 



### Is it a breaking change or non-breaking change?

Non-breaking change


### How can we test the before & after?

??
