### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ There is no interface available to add new settings. They are added by the devel
 ### Override existing configurations
 
 You can use this addon to make various Laravel configurations adjustable through the settings GUI, including Backpack settings themself.
-For example, you can override the Backpack `show_powered_by` or the `skin` setting in `/config/Backpack/base.php`.
+For example, you can override the Backpack `show_powered_by` setting in `/config/backpack/ui.php`.
 
 1. Create the setting entry in your settings database. You can add the settings manually, or via [Laravel seeders](https://laravel.com/docs/seeding). The values inserted into the database should be look similar to below:
 
@@ -87,19 +87,8 @@ For example, you can override the Backpack `show_powered_by` or the `skin` setti
    | value | 1 |
    | field | {"name":"value","label":"Value","type":"checkbox"} |
    | active | 1 |
-
-   For Backpack `Skin` setting:
-
-   | Field | Value |
-   | --- | --- |
-   | key | skin |
-   | name | Skin |
-   | description | Backpack admin panel skin settings. |
-   | value | skin-purple |
-   | field | {"name":"value","label":"Value","type":"select2_from_array","options":{"skin-black":"Black","skin-blue":"Blue",   "skin-purple":"Purple","skin-red":"Red","skin-yellow":"Yellow","skin-green":"Green","skin-blue-light":"Blue light",   "skin-black-light":"Black light","skin-purple-light":"Purple light","skin-green-light":"Green light","skin-red-light":"Red light",   "skin-yellow-light":"Yellow light"},"allows_null":false,"default":"skin-purple"} |
-   | active | 1 |
-
-2. Open up the `app/Providers/AppServiceProvider` file, and add the below lines:
+   
+3. Open up the `app/Providers/AppServiceProvider` file, and add the below lines:
 
    ```diff
    <?php
@@ -133,10 +122,9 @@ For example, you can override the Backpack `show_powered_by` or the `skin` setti
    +   protected function overrideConfigValues()
    +   {
    +       $config = [];
-   +       if (config('settings.skin'))
-   +           $config['backpack.base.skin'] = config('settings.skin');
-   +       if (config('settings.show_powered_by'))
-   +           $config['backpack.base.show_powered_by'] = config('settings.show_powered_by') == '1';
+   +       if (config('settings.show_powered_by')) {
+   +           $config['backpack.ui.show_powered_by'] = config('settings.show_powered_by') == '1';
+   +       }
    +       config($config);
    +   }
    }


### PR DESCRIPTION
## WHY

### BEFORE - What was wrong? What was happening before this PR?

We had wrong instructions in the README. 

Backpack v6 no longer uses the skin setting, plus the `show_powered_by` is now on `config/ui`
