### PR TITLE
Model Class Overwrite

### DIFF
--- a/src/SettingsServiceProvider.php
+++ b/src/SettingsServiceProvider.php
@@ -2,7 +2,6 @@
 
 namespace Backpack\Settings;
 
-use Backpack\Settings\app\Models\Setting;
 use Config;
 use Illuminate\Routing\Router;
 use Illuminate\Support\Facades\Schema;
@@ -42,8 +41,11 @@ class SettingsServiceProvider extends ServiceProvider
 
         // only use the Settings package if the Settings table is present in the database
         if (!\App::runningInConsole() && Schema::hasTable(config('backpack.settings.table_name'))) {
+            //get the model class from configuration
+            $modelClass = \Config::get('backpack.settings.model', \Backpack\Settings\app\Models\Setting::class);
+
             // get all settings from the database
-            $settings = Setting::all();
+            $settings = $modelClass::all();
 
             $config_prefix = config('backpack.settings.config_prefix');
 

--- a/src/SettingsServiceProvider.php
+++ b/src/SettingsServiceProvider.php
@@ -10,7 +10,7 @@ use Illuminate\Support\ServiceProvider;
 class SettingsServiceProvider extends ServiceProvider
 {
     /**
-     * Indicates if loading of the provider is deferred.
+     * Indicates if the loading of the provider is deferred.
      *
      * @var bool
      */
@@ -41,7 +41,7 @@ class SettingsServiceProvider extends ServiceProvider
 
         // only use the Settings package if the Settings table is present in the database
         if (!\App::runningInConsole() && Schema::hasTable(config('backpack.settings.table_name'))) {
-            //get the model class from configuration
+            //get the model class from the configuration
             $modelClass = \Config::get('backpack.settings.model', \Backpack\Settings\app\Models\Setting::class);
 
             // get all settings from the database
@@ -77,7 +77,7 @@ class SettingsServiceProvider extends ServiceProvider
      */
     public function setupRoutes(Router $router)
     {
-        // by default, use the routes file provided in vendor
+        // by default, use the routes file provided in the vendor
         $routeFilePathInUse = __DIR__.$this->routeFilePath;
 
         // but if there's a file with the same name in routes/backpack, use that one
@@ -97,6 +97,6 @@ class SettingsServiceProvider extends ServiceProvider
     {
         // register their aliases
         $loader = \Illuminate\Foundation\AliasLoader::getInstance();
-        $loader->alias('Setting', \Backpack\Settings\app\Models\Setting::class);
+        $loader->alias('Setting', config('backpack.settings.model',\Backpack\Settings\app\Models\Setting::class));
     }
 }

--- a/src/app/Http/Controllers/SettingCrudController.php
+++ b/src/app/Http/Controllers/SettingCrudController.php
@@ -12,7 +12,7 @@ class SettingCrudController extends CrudController
 
     public function setup()
     {
-        CRUD::setModel("Backpack\Settings\app\Models\Setting");
+        CRUD::setModel(config('backpack.settings.model',\Backpack\Settings\app\Models\Setting::class));
         CRUD::setEntityNameStrings(trans('backpack::settings.setting_singular'), trans('backpack::settings.setting_plural'));
         CRUD::setRoute(backpack_url(config('backpack.settings.route')));
     }

--- a/src/config/backpack/settings.php
+++ b/src/config/backpack/settings.php
@@ -42,7 +42,7 @@ return [
     |
     | WARNING: WE ADVISE TO NOT LEAVE THIS EMPTY / CHECK IF IT DOES NOT CONFLICT WITH OTHER CONFIG FILE NAMES
     |
-    |   - if you leave this empty and your keys match other configuration files you might ovetwrite them.
+    |   - if you leave this empty and your keys match other configuration files you might overwrite them.
     |
     */
     'config_prefix' => 'settings',

--- a/src/config/backpack/settings.php
+++ b/src/config/backpack/settings.php
@@ -14,6 +14,16 @@ return [
 
     /*
     |--------------------------------------------------------------------------
+    | Model Name
+    |--------------------------------------------------------------------------
+    |
+    | Settings Eloquent Model Class
+    |
+    */
+    'model' => \Backpack\Settings\app\Models\Setting::class,
+
+    /*
+    |--------------------------------------------------------------------------
     | Route
     |--------------------------------------------------------------------------
     |
@@ -28,11 +38,11 @@ return [
     |--------------------------------------------------------------------------
     |
     | The prefix used to add your settings into the configuration array.
-    | With this default you can grab your settings with: config('settings.your_setting_key')
+    | With this default you can grab your settings with config('settings.your_setting_key')
     |
     | WARNING: WE ADVISE TO NOT LEAVE THIS EMPTY / CHECK IF IT DOES NOT CONFLICT WITH OTHER CONFIG FILE NAMES
     |
-    |   - if you leave this empty and your keys match other configuration files you might ovewrite them.
+    |   - if you leave this empty and your keys match other configuration files you might ovetwrite them.
     |
     */
     'config_prefix' => 'settings',


### PR DESCRIPTION
## WHY
I wanted to have more control over how settings are handled, not just the table name.
### BEFORE - What was wrong? What was happening before this PR?

The Setting model that comes with package is called by setting crud controller and that was hardcoded.

### AFTER - What is happening after this PR?

Now user will have more flexible options to change the model class that is called and modify or extend functionality as per project need.

## HOW

### How did you achieve that, in technical terms?

1. Added a new configuration field named `model`. 
2. Changed value to controller setModel() method to configuration.
3. On the SettingServiceprovider register method change alias value.



### Is it a breaking change or non-breaking change?

Non-Breaking Change


### How can we test the before & after?

Change the model field value on configuration file and output config values will be given model instances.
