### PR TITLE
use backpack versions instead of Laravel versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 [![Style CI](https://styleci.io/repos/53683729/shield)](https://styleci.io/repos/53683729)
 [![Total Downloads][ico-downloads]][link-downloads]
 
-An interface for the administrator to easily change application settings. Uses Laravel Backpack. Works on Laravel 5.2 to Laravel 8.
+An interface for the administrator to easily change application settings. Uses Laravel Backpack. Works on Backpack v4, v5 and v6.
 
 > ### Security updates and breaking changes
 > Please **[subscribe to the Backpack Newsletter](http://backpackforlaravel.com/newsletter)** so you can find out about any security updates, breaking changes or major features. We send an email every 1-2 months.


### PR DESCRIPTION
## WHY

### BEFORE - What was wrong? What was happening before this PR?

This package depends on Backpack/CRUD not on Laravel. Having the supported Laravel versions was causing confusion without being necessary #140 

### AFTER - What is happening after this PR?

We mention the supported Backpack versions. 

