### PR TITLE
Having possiblity to set default value on Setting::get

### DIFF
--- a/src/app/Models/Setting.php
+++ b/src/app/Models/Setting.php
@@ -26,13 +26,13 @@ class Setting extends Model
      *
      * @return string The setting value.
      */
-    public static function get($key)
+    public static function get($key, $default = null)
     {
         $setting = new self();
         $entry = $setting->where('key', $key)->first();
 
         if (!$entry) {
-            return;
+            return $default;
         }
 
         return $entry->value;


### PR DESCRIPTION
Having possiblity to set default value on Setting::get

## WHY

Because, ti kind of logical for me that I get a setting or its default value when not set (or not active)

By the way, "active" field is not considered when picking setting value.
Is it an error ?
