### PR TITLE
Schema Facade was missing in migration file.

### DIFF
--- a/src/database/migrations/create_settings_table.php.stub
+++ b/src/database/migrations/create_settings_table.php.stub
@@ -2,6 +2,7 @@
 
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
 
 class CreateSettingsTable extends Migration
 {


### PR DESCRIPTION
## Schema Facade 

Schema Facade was missing so In IDE it was detecting error also error for pint.

So, just imported it.