### PR TITLE
Implement setting column resolution

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,50 @@
+name: Tests
+
+on:
+  push:
+    branches: [master, main]
+  pull_request:
+    branches: [master, main]
+
+jobs:
+  tests:
+    runs-on: ubuntu-latest
+
+    strategy:
+      fail-fast: false
+      matrix:
+        php: ['8.1', '8.2', '8.3', '8.4']
+        laravel: ['^10.0', '^11.0', '^12.0']
+        exclude:
+          - php: '8.1'
+            laravel: '^11.0'
+          - php: '8.1'
+            laravel: '^12.0'
+
+    name: PHP ${{ matrix.php }} / Laravel ${{ matrix.laravel }}
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: ${{ matrix.php }}
+          extensions: mbstring, dom, fileinfo, sqlite, pdo_sqlite
+          tools: composer:v2
+          coverage: none
+
+      - name: Cache Composer dependencies
+        uses: actions/cache@v4
+        with:
+          path: ~/.composer/cache/files
+          key: deps-laravel-${{ matrix.laravel }}-php-${{ matrix.php }}-${{ hashFiles('composer.json') }}
+
+      - name: Install dependencies
+        run: |
+          composer require "illuminate/support:${{ matrix.laravel }}" --no-interaction --no-update
+          composer install --prefer-dist --no-interaction --no-progress
+
+      - name: Run tests
+        run: vendor/bin/phpunit --testdox

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -17,8 +17,7 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          # Laravel 8 + crud v4 (PHP 7.4/8.0)
-          - { php: '7.4', laravel: '^8.0',  crud: '^4.0', phpunit: '^8.5|^9.0' }
+          # Laravel 8 + crud v4 (PHP 8.0)
           - { php: '8.0', laravel: '^8.0',  crud: '^4.0', phpunit: '^9.0' }
 
           # Laravel 9 + crud v5 (PHP 8.0/8.1)

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -6,22 +6,41 @@ on:
   pull_request:
     branches: [master, main]
 
+permissions:
+  contents: read
+
 jobs:
-  tests:
+  test:
     runs-on: ubuntu-latest
 
     strategy:
       fail-fast: false
       matrix:
-        php: ['8.1', '8.2', '8.3', '8.4']
-        laravel: ['^10.0', '^11.0', '^12.0']
-        exclude:
-          - php: '8.1'
-            laravel: '^11.0'
-          - php: '8.1'
-            laravel: '^12.0'
+        include:
+          # Laravel 8 + crud v4 (PHP 7.4/8.0)
+          - { php: '7.4', laravel: '^8.0',  crud: '^4.0', phpunit: '^8.5|^9.0' }
+          - { php: '8.0', laravel: '^8.0',  crud: '^4.0', phpunit: '^9.0' }
 
-    name: PHP ${{ matrix.php }} / Laravel ${{ matrix.laravel }}
+          # Laravel 9 + crud v5 (PHP 8.0/8.1)
+          - { php: '8.0', laravel: '^9.0',  crud: '^5.0', phpunit: '^9.0' }
+          - { php: '8.1', laravel: '^9.0',  crud: '^5.0', phpunit: '^9.0' }
+
+          # Laravel 10/11 + crud v6 (PHP 8.1–8.3)
+          - { php: '8.1', laravel: '^10.0', crud: '^6.0', phpunit: '^10.0' }
+          - { php: '8.2', laravel: '^10.0', crud: '^6.0', phpunit: '^10.0' }
+          - { php: '8.2', laravel: '^11.0', crud: '^6.0', phpunit: '^10.0|^11.0' }
+          - { php: '8.3', laravel: '^11.0', crud: '^6.0', phpunit: '^11.0' }
+
+          # Laravel 12/13 + crud v7 (PHP 8.2–8.5)
+          - { php: '8.2', laravel: '^12.0', crud: '^7.0', phpunit: '^11.0' }
+          - { php: '8.3', laravel: '^12.0', crud: '^7.0', phpunit: '^11.0' }
+          - { php: '8.4', laravel: '^12.0', crud: '^7.0', phpunit: '^11.0' }
+          - { php: '8.5', laravel: '^12.0', crud: '^7.0', phpunit: '^11.0' }
+          - { php: '8.3', laravel: '^13.0', crud: '^7.0', phpunit: '^11.0' }
+          - { php: '8.4', laravel: '^13.0', crud: '^7.0', phpunit: '^11.0' }
+          - { php: '8.5', laravel: '^13.0', crud: '^7.0', phpunit: '^11.0' }
+
+    name: PHP ${{ matrix.php }}, Laravel ${{ matrix.laravel }}, CRUD ${{ matrix.crud }}, PHPUnit ${{ matrix.phpunit }}
 
     steps:
       - name: Checkout code
@@ -31,20 +50,19 @@ jobs:
         uses: shivammathur/setup-php@v2
         with:
           php-version: ${{ matrix.php }}
-          extensions: mbstring, dom, fileinfo, sqlite, pdo_sqlite
-          tools: composer:v2
+          extensions: curl, mbstring, zip, pcntl, pdo, sqlite, pdo_sqlite, iconv
           coverage: none
 
-      - name: Cache Composer dependencies
+      - name: Cache dependencies
         uses: actions/cache@v4
         with:
           path: ~/.composer/cache/files
-          key: deps-laravel-${{ matrix.laravel }}-php-${{ matrix.php }}-${{ hashFiles('composer.json') }}
+          key: dependencies-laravel-${{ matrix.laravel }}-crud-${{ matrix.crud }}-php-${{ matrix.php }}-phpunit-${{ matrix.phpunit }}-composer-${{ hashFiles('composer.json') }}
 
       - name: Install dependencies
         run: |
-          composer require "illuminate/support:${{ matrix.laravel }}" --no-interaction --no-update
-          composer install --prefer-dist --no-interaction --no-progress
+          composer require "laravel/framework:${{ matrix.laravel }}" "backpack/crud:${{ matrix.crud }}" "phpunit/phpunit:${{ matrix.phpunit }}" --no-interaction --no-update
+          composer update --prefer-stable --prefer-dist --no-interaction
 
-      - name: Run tests
-        run: vendor/bin/phpunit --testdox
+      - name: Execute tests
+        run: composer test

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![Latest Version on Packagist][ico-version]][link-packagist]
 [![Software License][ico-license]](LICENSE.md)
-[![Build Status][ico-travis]][link-travis]
+[![Tests][ico-tests]][link-tests]
 [![Coverage Status][ico-scrutinizer]][link-scrutinizer]
 [![Quality Score][ico-code-quality]][link-code-quality]
 [![Style CI](https://styleci.io/repos/53683729/shield)](https://styleci.io/repos/53683729)
@@ -132,6 +132,113 @@ For example, you can override the Backpack `show_powered_by` setting in `/config
    }
    ```
 
+### Formatting values in the list view
+
+The `field` JSON describes how a setting is **edited**. Backpack also needs to know how each setting's value should be **displayed** in the list (the `value` column). The package gives you two ways to control this:
+
+- **Per-row explicit override** via the optional `column` DB field — always honored, no global config needed.
+- **Automatic resolution from the field** via `field_to_column_map` — opt-in via the `auto_resolve_columns` config flag (off by default for backward compatibility; will default to `true` in the next major version).
+
+Resolution order for each row:
+
+1. **Explicit `column` definition** (recommended for full control) — if the row's `column` DB field contains a JSON column definition, it's used as-is. This works whether or not `auto_resolve_columns` is enabled.
+2. **Derived from `field`** (only when `auto_resolve_columns` is `true`) — the package translates the row's `field` JSON into a matching column definition using a configurable map (e.g. `datetime` field → `datetime` column, `checkbox` → `boolean`, `select_from_array` → `select_from_array`, `upload` → `upload`, `repeatable` → `repeatable`, etc.). Every key from the field definition is forwarded to the column **except** a small blacklist of form-only keys (`attributes`, `wrapperAttributes`, `hint`, `placeholder`, `validation`/`validationRules`/`validationMessages`, `tab`, `fake`, `store_in`, `dependencies`, `on_change`, `view_namespace`, `inline_create`, `ajax`, `minimum_input_length`, `pivotSelect`, `force_select`, `datetime_picker_options`, `date_picker_options`, `readonly`, `disabled`, `autocomplete`, `allows_null`, `allows_multiple`, and similar). Column-specific keys like `temporary`, `expiration`, `height`, `width`, `radius`, `subfields`, `entity`, `model`, `attribute`, `relation_type`, `pivot`, `key`, `prefix`, `disk`, `withFiles`, `withMedia` — present or future — flow through automatically.
+3. **Fallback** — plain text (the legacy behavior).
+
+#### Enabling auto-resolution
+
+In `config/backpack/settings.php`:
+
+```php
+'auto_resolve_columns' => true,
+```
+
+After enabling it, a datetime setting with a custom format
+
+```
+| Field  | Value                                                                                |
+| key    | last_incident                                                                        |
+| field  | {"name":"value","label":"Last Incident","type":"datetime","format":"M/D/YY h:mm A"}   |
+| value  | 2026-05-08T11:00                                                                     |
+```
+
+will render as `5/8/26 11:00 AM` in the list, with no further configuration.
+
+#### Per-row explicit override
+
+You can store a column definition on any setting row, independently of the global flag — useful when you want a different display than what the field implies:
+
+```
+| Field  | Value                                                                                                  |
+| field  | {"name":"value","label":"API token","type":"text"}                                                     |
+| column | {"name":"value","label":"API token","type":"text","limit":12,"prefix":"\u2026"}                        |
+| value  | sk-live-1234567890abcdef                                                                               |
+```
+
+This requires the optional `column` DB field (see Upgrading section below for existing installations).
+
+#### Customizing the field-to-column map
+
+The mapping table lives in `config/backpack/settings.php` under `field_to_column_map`. Add or override entries to support custom field types or change how a type is rendered, without forking the package:
+
+```php
+'field_to_column_map' => [
+    // ...defaults...
+    'my_custom_field' => 'my_custom_column',
+    'tinymce'         => 'custom_html', // override default
+],
+```
+
+#### Upload columns with `withFiles` / `withMedia`
+
+Backpack's `upload`, `upload_multiple` and `image` columns can be configured with `->withFiles([...])` or `->withMedia([...])` to delegate path resolution to Backpack's uploaders (or to Spatie's Media Library, via [backpack/medialibrary-uploaders](https://github.com/Laravel-Backpack/medialibrary-uploaders)). In a normal CRUD this works because `setupListOperation()` calls the macro on a `CrudColumn` instance, which registers a `Model::retrieved` event that hydrates raw stored data (a path / a JSON array / a media id) into the URL the column actually displays.
+
+In Settings every row shares the same `Setting` model and the same `value` attribute, so a global retrieved event can't be used — the last uploader would win for every row. Instead, this package hydrates upload values **per row, on demand**, right before the cell is rendered. Put a column definition like this on the row (either via the `column` DB field or via auto-resolution of a `withFiles`-configured field):
+
+```json
+{
+  "name": "value",
+  "type": "upload",
+  "withFiles": { "disk": "public", "path": "settings" }
+}
+```
+
+The package will:
+- look up the right uploader class via Backpack's `UploadersRepository` (or honor an explicit `uploader` key on the definition),
+- run its `retrieveUploadedFiles()` against the current setting row only,
+- then render the upload column view with the resolved value.
+
+This works for `withFiles`, `withMedia` and any custom uploader registered with the repository. If neither macro is present, the upload column falls back to its default behavior (treat `value` as a raw path on `disk`).
+
+### Upgrading from earlier versions
+
+**This release is fully backward compatible by default.** If you simply update the package, your existing settings list looks and behaves exactly as before — every value cell still renders as raw text, and no migration is required.
+
+To opt into the new features:
+
+1. Publish the new config (or hand-merge the `auto_resolve_columns`, `field_to_column_map` and `column_migration_name` keys):
+
+   ```bash
+   php artisan vendor:publish --provider="Backpack\Settings\SettingsServiceProvider" --tag="config"
+   ```
+
+2. To enable automatic per-type formatting in the list, set:
+
+   ```php
+   'auto_resolve_columns' => true,
+   ```
+
+3. (Optional) To use per-row explicit `column` overrides, publish and run the additive migration that adds the nullable `column` text field:
+
+   ```bash
+   php artisan vendor:publish --provider="Backpack\Settings\SettingsServiceProvider" --tag="migrations"
+   php artisan migrate
+   ```
+
+   This migration is fully additive — the package works without it. Without it, only auto-resolution (and the legacy plain-text fallback) is available.
+
+In the next major version, `auto_resolve_columns` will default to `true`.
+
 ## Screenshots
 
 See [backpackforlaravel.com](https://backpackforlaravel.com)
@@ -185,13 +292,13 @@ If you are looking for a developer/team to help you build an admin panel on Lara
 
 [ico-version]: https://img.shields.io/packagist/v/backpack/settings.svg?style=flat-square
 [ico-license]: https://img.shields.io/badge/license-dual-blue?style=flat-square
-[ico-travis]: https://img.shields.io/travis/com/laravel-backpack/settings
+[ico-tests]: https://img.shields.io/github/actions/workflow/status/Laravel-Backpack/Settings/tests.yml?branch=master&label=tests&style=flat-square
 [ico-scrutinizer]: https://img.shields.io/scrutinizer/coverage/g/laravel-backpack/settings.svg?style=flat-square
 [ico-code-quality]: https://img.shields.io/scrutinizer/g/laravel-backpack/settings.svg?style=flat-square
 [ico-downloads]: https://img.shields.io/packagist/dt/backpack/settings.svg?style=flat-square
 
 [link-packagist]: https://packagist.org/packages/backpack/settings
-[link-travis]: https://travis-ci.org/laravel-backpack/settings
+[link-tests]: https://github.com/Laravel-Backpack/Settings/actions/workflows/tests.yml
 [link-scrutinizer]: https://scrutinizer-ci.com/g/laravel-backpack/settings/code-structure
 [link-code-quality]: https://scrutinizer-ci.com/g/laravel-backpack/settings
 [link-downloads]: https://packagist.org/packages/backpack/settings

--- a/composer.json
+++ b/composer.json
@@ -25,10 +25,11 @@
     "minimum-stability": "dev",
     "prefer-stable": true,
     "require": {
+        "php": "^7.3|^8.0",
         "backpack/crud": "^4.0|^5.0|^6.0|^7.0"
     },
     "require-dev": {
-        "phpunit/phpunit" : "^11.0|^10.0|^9.0|^7.0",
+        "phpunit/phpunit": "^8.0|^9.0|^10.0|^11.0",
         "scrutinizer/ocular": "~1.1"
     },
     "autoload": {

--- a/composer.json
+++ b/composer.json
@@ -25,12 +25,11 @@
     "minimum-stability": "dev",
     "prefer-stable": true,
     "require": {
-        "php": "^7.3|^8.0",
+        "php": "^8.0",
         "backpack/crud": "^4.0|^5.0|^6.0|^7.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "^8.0|^9.0|^10.0|^11.0",
-        "scrutinizer/ocular": "~1.1"
+        "phpunit/phpunit": "^8.0|^9.0|^10.0|^11.0"
     },
     "autoload": {
         "psr-4": {

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,11 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit backupGlobals="false"
-         backupStaticAttributes="false"
-         bootstrap="vendor/autoload.php"
+<phpunit bootstrap="vendor/autoload.php"
          colors="true"
-         convertErrorsToExceptions="true"
-         convertNoticesToExceptions="true"
-         convertWarningsToExceptions="true"
          processIsolation="false"
          stopOnFailure="false"
 >
@@ -14,4 +9,9 @@
             <directory suffix=".php">./tests/</directory>
         </testsuite>
     </testsuites>
+    <source>
+        <include>
+            <directory suffix=".php">src/</directory>
+        </include>
+    </source>
 </phpunit>

--- a/src/SettingsServiceProvider.php
+++ b/src/SettingsServiceProvider.php
@@ -3,6 +3,7 @@
 namespace Backpack\Settings;
 
 use Illuminate\Support\Facades\App;
+use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Facades\Schema;
 use Illuminate\Support\ServiceProvider;
 
@@ -45,16 +46,15 @@ class SettingsServiceProvider extends ServiceProvider
             /** @var \Illuminate\Database\Eloquent\Model $modelClass */
             $modelClass = config('backpack.settings.model', \Backpack\Settings\app\Models\Setting::class);
 
-            // get all settings from the database
-            $settings = $modelClass::all();
+            $settings = $this->getCachedSettings($modelClass);
 
             $config_prefix = config('backpack.settings.config_prefix');
 
             // bind all settings to the Laravel config, so you can call them like
             // Config::get('settings.contact_email')
             foreach ($settings as $key => $setting) {
-                $prefixed_key = !empty($config_prefix) ? $config_prefix.'.'.$setting->key : $setting->key;
-                config([$prefixed_key => $setting->value]);
+                $prefixed_key = !empty($config_prefix) ? $config_prefix.'.'.$setting['key'] : $setting['key'];
+                config([$prefixed_key => $setting['value']]);
             }
         }
         // publish the migrations and seeds
@@ -98,5 +98,40 @@ class SettingsServiceProvider extends ServiceProvider
         // register their aliases
         $loader = \Illuminate\Foundation\AliasLoader::getInstance();
         $loader->alias('Setting', config('backpack.settings.model', \Backpack\Settings\app\Models\Setting::class));
+    }
+
+    /**
+     * Load all settings, using a cached array when caching is enabled.
+     * Returns an array of ['key' => ..., 'value' => ...] entries.
+     */
+    protected function getCachedSettings(string $modelClass): array
+    {
+        $loader = fn () => $modelClass::all(['key', 'value'])
+            ->map(fn ($s) => ['key' => $s->key, 'value' => $s->value])
+            ->all();
+
+        if (!config('backpack.settings.cache.enabled', true)) {
+            return $loader();
+        }
+
+        $store = config('backpack.settings.cache.store');
+        $key   = config('backpack.settings.cache.key', 'backpack.settings.all');
+        $ttl   = (int) config('backpack.settings.cache.ttl', 60 * 60 * 24 * 30);
+
+        return Cache::store($store)->remember($key, $ttl, $loader);
+    }
+
+    /**
+     * Forget the cached settings payload. Called from the Setting model on
+     * saved/deleted events so changes are picked up on the next request.
+     */
+    public static function forgetCache(): void
+    {
+        if (!config('backpack.settings.cache.enabled', true)) {
+            return;
+        }
+
+        Cache::store(config('backpack.settings.cache.store'))
+            ->forget(config('backpack.settings.cache.key', 'backpack.settings.all'));
     }
 }

--- a/src/SettingsServiceProvider.php
+++ b/src/SettingsServiceProvider.php
@@ -38,6 +38,10 @@ class SettingsServiceProvider extends ServiceProvider
         // define the routes for the application
         $this->setupRoutes();
 
+        // register our blade view namespace so columns can be dispatched
+        // per-row via Backpack's view_namespace mechanism.
+        $this->loadViewsFrom(__DIR__.'/resources/views', 'backpack-settings');
+
         // only use the Settings package if the Settings table is present in the database
         if (!App::runningInConsole() && Schema::hasTable(config('backpack.settings.table_name'))) {
             /** @var \Illuminate\Database\Eloquent\Model $modelClass */
@@ -58,6 +62,7 @@ class SettingsServiceProvider extends ServiceProvider
         // publish the migrations and seeds
         $this->publishes([
             __DIR__.'/database/migrations/create_settings_table.php.stub' => database_path('migrations/'.config('backpack.settings.migration_name').'.php'),
+            __DIR__.'/database/migrations/add_column_to_settings_table.php.stub' => database_path('migrations/'.config('backpack.settings.column_migration_name', '2026_05_29_000000_add_column_to_settings_table').'.php'),
         ], 'migrations');
 
         // publish translation files

--- a/src/SettingsServiceProvider.php
+++ b/src/SettingsServiceProvider.php
@@ -115,8 +115,8 @@ class SettingsServiceProvider extends ServiceProvider
         }
 
         $store = config('backpack.settings.cache.store');
-        $key   = config('backpack.settings.cache.key', 'backpack.settings.all');
-        $ttl   = (int) config('backpack.settings.cache.ttl', 60 * 60 * 24 * 30);
+        $key = config('backpack.settings.cache.key', 'backpack.settings.all');
+        $ttl = (int) config('backpack.settings.cache.ttl', 60 * 60 * 24 * 30);
 
         return Cache::store($store)->remember($key, $ttl, $loader);
     }

--- a/src/SettingsServiceProvider.php
+++ b/src/SettingsServiceProvider.php
@@ -38,8 +38,6 @@ class SettingsServiceProvider extends ServiceProvider
         // define the routes for the application
         $this->setupRoutes();
 
-        // register our blade view namespace so columns can be dispatched
-        // per-row via Backpack's view_namespace mechanism.
         $this->loadViewsFrom(__DIR__.'/resources/views', 'backpack-settings');
 
         // only use the Settings package if the Settings table is present in the database

--- a/src/SettingsServiceProvider.php
+++ b/src/SettingsServiceProvider.php
@@ -59,7 +59,7 @@ class SettingsServiceProvider extends ServiceProvider
         }
         // publish the migrations and seeds
         $this->publishes([
-            __DIR__.'/database/migrations/create_settings_table.php.stub' => database_path('migrations/'.config('backpack.settings.migration_name').'.php'),
+            __DIR__.'/database/migrations/create_settings_table.php.stub'        => database_path('migrations/'.config('backpack.settings.migration_name').'.php'),
             __DIR__.'/database/migrations/add_column_to_settings_table.php.stub' => database_path('migrations/'.config('backpack.settings.column_migration_name', '2026_05_29_000000_add_column_to_settings_table').'.php'),
         ], 'migrations');
 

--- a/src/app/Http/Controllers/SettingCrudController.php
+++ b/src/app/Http/Controllers/SettingCrudController.php
@@ -29,8 +29,14 @@ class SettingCrudController extends CrudController
                 'label' => trans('backpack::settings.name'),
             ],
             [
-                'name'  => 'value',
-                'label' => trans('backpack::settings.value'),
+                // Per-row column dispatcher: each setting renders its
+                // `value` cell using either an explicit `column` JSON
+                // definition stored on the row, or one derived from the
+                // row's `field` JSON via the FieldToColumnResolver.
+                'name'           => 'value',
+                'label'          => trans('backpack::settings.value'),
+                'type'           => 'setting_value',
+                'view_namespace' => 'backpack-settings::columns',
             ],
             [
                 'name'  => 'description',

--- a/src/app/Http/Controllers/SettingCrudController.php
+++ b/src/app/Http/Controllers/SettingCrudController.php
@@ -29,10 +29,6 @@ class SettingCrudController extends CrudController
                 'label' => trans('backpack::settings.name'),
             ],
             [
-                // Per-row column dispatcher: each setting renders its
-                // `value` cell using either an explicit `column` JSON
-                // definition stored on the row, or one derived from the
-                // row's `field` JSON via the FieldToColumnResolver.
                 'name'           => 'value',
                 'label'          => trans('backpack::settings.value'),
                 'type'           => 'setting_value',

--- a/src/app/Library/FieldToColumnResolver.php
+++ b/src/app/Library/FieldToColumnResolver.php
@@ -3,93 +3,31 @@
 namespace Backpack\Settings\app\Library;
 
 /**
- * Translates a Backpack field definition (used to edit a setting on the
- * Update page) into a Backpack column definition (used to display the
- * setting's value on the List page).
+ * Translates a Backpack field definition into a column definition for the list view.
  *
- * This is a thin, declarative mapper. It does not format values itself —
- * it produces a column definition array that Backpack's column views can
- * render natively, so every existing and future column type "just works".
- *
- * Strategy: blacklist form-only keys, pass everything else through.
- *
- * Why a blacklist instead of a whitelist? Each Backpack column type has
- * its own set of accepted attributes (`upload` uses `disk`, `prefix`,
- * `temporary`, `expiration`; `image` adds `height`, `width`, `radius`;
- * `repeatable` uses `subfields`; relationship columns add `entity`,
- * `model`, `attribute`, `relation_type`, `pivot`, `key`; new column types
- * appear in every Backpack release). Maintaining a whitelist of every
- * column attribute is fragile. The set of *form-only* keys, however, is
- * tied to Laravel form / validation mechanics and to Backpack's form
- * builder — it's a small, stable list. So we strip the bad keys and let
- * the rest flow through.
+ * Strategy: strip form-only keys, pass everything else through, then remap the type.
+ * Blacklist (not whitelist) because column attributes vary per type and per Backpack release.
  */
 class FieldToColumnResolver
 {
-    /**
-     * Keys that exist on field definitions but have no meaning — or worse,
-     * harmful meaning — on column definitions. Stripped before forwarding.
-     *
-     * Categories covered:
-     *  - HTML form mechanics:           attributes, wrapperAttributes,
-     *                                   placeholder, hint, readonly,
-     *                                   disabled, autocomplete
-     *  - Laravel validation:            validation, validationRules,
-     *                                   validationMessages, allows_null,
-     *                                   allows_multiple
-     *  - Backpack form layout / state:  tab, fake, store_in, dependencies,
-     *                                   on_change, new_item_label
-     *  - Custom view dispatch:          view_namespace (points at FIELD
-     *                                   views; if leaked, the column slot
-     *                                   would try to render a field view)
-     *  - Field-builder helpers:         field_unique_name, parent_field,
-     *                                   parentFieldName, container_name
-     *  - Pro / Ajax / Inline-create:    ajax, minimum_input_length,
-     *                                   inline_create, pivotSelect,
-     *                                   force_select, include_all_form_fields
-     *
-     * Notably NOT stripped: `withFiles` and `withMedia`. These are macros
-     * registered on BOTH CrudField and CrudColumn (see
-     * backpack/crud/src/macros.php and backpack/medialibrary-uploaders).
-     * They store the upload definition and register the events that
-     * hydrate stored values for display, so they must flow through to the
-     * column or upload values won't render correctly.
-     */
+    // Form-only keys that must NOT leak onto a column definition.
+    // `view_namespace` is especially dangerous: it points at field views.
+    // `withFiles` / `withMedia` are intentionally NOT here — they're macros registered on
+    // CrudColumn too (see backpack/crud/src/macros.php) and drive uploader hydration.
     protected const STRIP_KEYS = [
-        // HTML form mechanics
         'attributes', 'wrapperAttributes', 'placeholder', 'hint',
         'readonly', 'disabled', 'autocomplete',
-
-        // Laravel validation
         'validation', 'validationRules', 'validationMessages',
         'allows_null', 'allows_multiple',
-
-        // Backpack form layout / state
-        'tab', 'fake', 'store_in', 'dependencies', 'on_change',
-        'new_item_label',
-
-        // Custom view dispatch (CRITICAL: points at field views)
+        'tab', 'fake', 'store_in', 'dependencies', 'on_change', 'new_item_label',
         'view_namespace',
-
-        // Field-builder helpers (set at runtime, never useful on columns)
         'field_unique_name', 'parent_field', 'parentFieldName',
         'container_name', 'show_asterisk', 'parent_path',
-
-        // Pro: ajax / inline-create / relationship form helpers
         'ajax', 'minimum_input_length', 'inline_create', 'pivotSelect',
         'force_select', 'include_all_form_fields', 'method',
-
-        // *_picker form-config arrays (relevant displayFormat is harvested
-        // separately into `format` before stripping)
         'datetime_picker_options', 'date_picker_options',
     ];
 
-    /**
-     * Field-type -> column-type map. When null, the resolver will read
-     * `backpack.settings.field_to_column_map` from the Laravel config.
-     *
-     * @var array|null
-     */
     protected $map;
 
     public function __construct(?array $map = null)
@@ -97,12 +35,6 @@ class FieldToColumnResolver
         $this->map = $map;
     }
 
-    /**
-     * Build a column definition from a field definition.
-     *
-     * @param  array|null  $field  The decoded `field` JSON of a setting row.
-     * @return array  A column definition suitable for CRUD::addColumn().
-     */
     public function resolve(?array $field): array
     {
         $field = $field ?: [];
@@ -111,8 +43,7 @@ class FieldToColumnResolver
         $map = $this->map ?? (array) config('backpack.settings.field_to_column_map', []);
         $columnType = $map[$fieldType] ?? 'text';
 
-        // datetime/date columns: harvest the picker's display format into
-        // `format` BEFORE stripping the picker option arrays.
+        // Harvest the picker's display format before stripping the picker option arrays.
         if (in_array($columnType, ['datetime', 'date'], true) && empty($field['format'])) {
             $displayFormat = $field['datetime_picker_options']['displayFormat']
                 ?? $field['date_picker_options']['format']
@@ -123,13 +54,11 @@ class FieldToColumnResolver
             }
         }
 
-        // start from the full field definition, minus form-only keys
         $column = $field;
         foreach (self::STRIP_KEYS as $key) {
             unset($column[$key]);
         }
 
-        // overwrite type, ensure name defaults to 'value'
         $column['type'] = $columnType;
         $column['name'] = $field['name'] ?? 'value';
 

--- a/src/app/Library/FieldToColumnResolver.php
+++ b/src/app/Library/FieldToColumnResolver.php
@@ -1,0 +1,138 @@
+<?php
+
+namespace Backpack\Settings\app\Library;
+
+/**
+ * Translates a Backpack field definition (used to edit a setting on the
+ * Update page) into a Backpack column definition (used to display the
+ * setting's value on the List page).
+ *
+ * This is a thin, declarative mapper. It does not format values itself —
+ * it produces a column definition array that Backpack's column views can
+ * render natively, so every existing and future column type "just works".
+ *
+ * Strategy: blacklist form-only keys, pass everything else through.
+ *
+ * Why a blacklist instead of a whitelist? Each Backpack column type has
+ * its own set of accepted attributes (`upload` uses `disk`, `prefix`,
+ * `temporary`, `expiration`; `image` adds `height`, `width`, `radius`;
+ * `repeatable` uses `subfields`; relationship columns add `entity`,
+ * `model`, `attribute`, `relation_type`, `pivot`, `key`; new column types
+ * appear in every Backpack release). Maintaining a whitelist of every
+ * column attribute is fragile. The set of *form-only* keys, however, is
+ * tied to Laravel form / validation mechanics and to Backpack's form
+ * builder — it's a small, stable list. So we strip the bad keys and let
+ * the rest flow through.
+ */
+class FieldToColumnResolver
+{
+    /**
+     * Keys that exist on field definitions but have no meaning — or worse,
+     * harmful meaning — on column definitions. Stripped before forwarding.
+     *
+     * Categories covered:
+     *  - HTML form mechanics:           attributes, wrapperAttributes,
+     *                                   placeholder, hint, readonly,
+     *                                   disabled, autocomplete
+     *  - Laravel validation:            validation, validationRules,
+     *                                   validationMessages, allows_null,
+     *                                   allows_multiple
+     *  - Backpack form layout / state:  tab, fake, store_in, dependencies,
+     *                                   on_change, new_item_label
+     *  - Custom view dispatch:          view_namespace (points at FIELD
+     *                                   views; if leaked, the column slot
+     *                                   would try to render a field view)
+     *  - Field-builder helpers:         field_unique_name, parent_field,
+     *                                   parentFieldName, container_name
+     *  - Pro / Ajax / Inline-create:    ajax, minimum_input_length,
+     *                                   inline_create, pivotSelect,
+     *                                   force_select, include_all_form_fields
+     *
+     * Notably NOT stripped: `withFiles` and `withMedia`. These are macros
+     * registered on BOTH CrudField and CrudColumn (see
+     * backpack/crud/src/macros.php and backpack/medialibrary-uploaders).
+     * They store the upload definition and register the events that
+     * hydrate stored values for display, so they must flow through to the
+     * column or upload values won't render correctly.
+     */
+    protected const STRIP_KEYS = [
+        // HTML form mechanics
+        'attributes', 'wrapperAttributes', 'placeholder', 'hint',
+        'readonly', 'disabled', 'autocomplete',
+
+        // Laravel validation
+        'validation', 'validationRules', 'validationMessages',
+        'allows_null', 'allows_multiple',
+
+        // Backpack form layout / state
+        'tab', 'fake', 'store_in', 'dependencies', 'on_change',
+        'new_item_label',
+
+        // Custom view dispatch (CRITICAL: points at field views)
+        'view_namespace',
+
+        // Field-builder helpers (set at runtime, never useful on columns)
+        'field_unique_name', 'parent_field', 'parentFieldName',
+        'container_name', 'show_asterisk', 'parent_path',
+
+        // Pro: ajax / inline-create / relationship form helpers
+        'ajax', 'minimum_input_length', 'inline_create', 'pivotSelect',
+        'force_select', 'include_all_form_fields', 'method',
+
+        // *_picker form-config arrays (relevant displayFormat is harvested
+        // separately into `format` before stripping)
+        'datetime_picker_options', 'date_picker_options',
+    ];
+
+    /**
+     * Field-type -> column-type map. When null, the resolver will read
+     * `backpack.settings.field_to_column_map` from the Laravel config.
+     *
+     * @var array|null
+     */
+    protected $map;
+
+    public function __construct(?array $map = null)
+    {
+        $this->map = $map;
+    }
+
+    /**
+     * Build a column definition from a field definition.
+     *
+     * @param  array|null  $field  The decoded `field` JSON of a setting row.
+     * @return array  A column definition suitable for CRUD::addColumn().
+     */
+    public function resolve(?array $field): array
+    {
+        $field = $field ?: [];
+
+        $fieldType = $field['type'] ?? 'text';
+        $map = $this->map ?? (array) config('backpack.settings.field_to_column_map', []);
+        $columnType = $map[$fieldType] ?? 'text';
+
+        // datetime/date columns: harvest the picker's display format into
+        // `format` BEFORE stripping the picker option arrays.
+        if (in_array($columnType, ['datetime', 'date'], true) && empty($field['format'])) {
+            $displayFormat = $field['datetime_picker_options']['displayFormat']
+                ?? $field['date_picker_options']['format']
+                ?? null;
+
+            if ($displayFormat) {
+                $field['format'] = $displayFormat;
+            }
+        }
+
+        // start from the full field definition, minus form-only keys
+        $column = $field;
+        foreach (self::STRIP_KEYS as $key) {
+            unset($column[$key]);
+        }
+
+        // overwrite type, ensure name defaults to 'value'
+        $column['type'] = $columnType;
+        $column['name'] = $field['name'] ?? 'value';
+
+        return $column;
+    }
+}

--- a/src/app/Library/UploaderColumnHydrator.php
+++ b/src/app/Library/UploaderColumnHydrator.php
@@ -5,68 +5,33 @@ namespace Backpack\Settings\app\Library;
 use Illuminate\Database\Eloquent\Model;
 
 /**
- * Resolves stored upload values into displayable form for a single Setting
- * row, just before the list-view column is rendered.
+ * Hydrates uploader-managed values on a Setting row before its upload column renders.
  *
- * Why this exists: the normal Backpack upload pipeline relies on
- * `CrudColumn::withFiles([...])` (or `->withMedia([...])`) being called
- * inside `setupListOperation()`. That macro registers a `Model::retrieved`
- * event that runs the configured uploader's `retrieveUploadedFiles()` to
- * transform raw stored data (a path, a JSON array of paths, a media id,
- * ...) into the URL the upload column view actually renders.
- *
- * In Settings we can't use that mechanism: every row is the SAME `Setting`
- * model with the SAME column name (`value`), but each row may have a
- * DIFFERENT uploader configuration. Registering one global retrieved event
- * per row would make every uploader run against every row's value and the
- * last one would win.
- *
- * So instead of registering events, we resolve the value per-row, on
- * demand, against just the current entry — same call the event would make
- * (`$uploader->retrieveUploadedFiles($entry)`), but scoped to one row.
+ * The normal Backpack flow uses a `Model::retrieved` event registered by the
+ * `withFiles` / `withMedia` macro. We can't use it: all Setting rows share the same
+ * model and `value` attribute, so a global event would let the last uploader win.
+ * Instead we run the uploader inline, per row, on this $entry only.
  */
 class UploaderColumnHydrator
 {
-    /**
-     * Column types this hydrator is allowed to act on.
-     */
     protected const UPLOAD_COLUMN_TYPES = ['upload', 'upload_multiple', 'image'];
 
-    /**
-     * Resolve any uploader-managed value on $entry->{column['name']}
-     * in-place so the column view can render the URL(s).
-     *
-     * Safe no-op when:
-     *  - the column isn't an upload column type, or
-     *  - the column has no `withFiles` / `withMedia` definition, or
-     *  - the UploadersRepository / requested uploader isn't available
-     *    (e.g. medialibrary-uploaders not installed).
-     */
-    public static function hydrate(Model $entry, array $column): Model
+    public static function hydrate(Model $entry, array &$column): Model
     {
         if (! in_array($column['type'] ?? null, self::UPLOAD_COLUMN_TYPES, true)) {
             return $entry;
         }
 
-        // Find which uploader macro applies. Order matters: only one wins.
         $macro = isset($column['withFiles']) ? 'withFiles'
                : (isset($column['withMedia']) ? 'withMedia' : null);
 
-        if ($macro === null) {
-            return $entry;
-        }
-
-        // UploadersRepository is registered by backpack/crud's service
-        // provider. Bail out cleanly if the host app doesn't have it.
-        if (! app()->bound('UploadersRepository')) {
+        if ($macro === null || ! app()->bound('UploadersRepository')) {
             return $entry;
         }
 
         $uploadDefinition = is_array($column[$macro]) ? $column[$macro] : [];
         $uploaderClass    = $uploadDefinition['uploader'] ?? null;
 
-        // If no custom uploader was provided, look up the default for this
-        // column type + macro pair (e.g. ['upload' => SingleFile::class]).
         if ($uploaderClass === null) {
             $repository = app('UploadersRepository');
 
@@ -77,9 +42,20 @@ class UploaderColumnHydrator
             $uploaderClass = $repository->getUploadFor($column['type'], $macro);
         }
 
-        // Build the uploader the same way RegisterUploadEvents does, but
-        // never register model events — we run it inline on this $entry.
         $uploader = $uploaderClass::for($column, $uploadDefinition);
+
+        // Mirror RegisterUploadEvents::setupUploadConfigsInCrudObject() — the upload
+        // column view reads these directly off the column array.
+        if (method_exists($uploader, 'getDisk')) {
+            $column['disk'] = $uploader->getDisk();
+        }
+        if (method_exists($uploader, 'getPath')) {
+            $column['prefix'] = $uploader->getPath();
+        }
+        if (method_exists($uploader, 'useTemporaryUrl') && $uploader->useTemporaryUrl()) {
+            $column['temporary']  = true;
+            $column['expiration'] = $uploader->getExpirationTimeInMinutes();
+        }
 
         return $uploader->retrieveUploadedFiles($entry);
     }

--- a/src/app/Library/UploaderColumnHydrator.php
+++ b/src/app/Library/UploaderColumnHydrator.php
@@ -18,24 +18,24 @@ class UploaderColumnHydrator
 
     public static function hydrate(Model $entry, array &$column): Model
     {
-        if (! in_array($column['type'] ?? null, self::UPLOAD_COLUMN_TYPES, true)) {
+        if (!in_array($column['type'] ?? null, self::UPLOAD_COLUMN_TYPES, true)) {
             return $entry;
         }
 
         $macro = isset($column['withFiles']) ? 'withFiles'
                : (isset($column['withMedia']) ? 'withMedia' : null);
 
-        if ($macro === null || ! app()->bound('UploadersRepository')) {
+        if ($macro === null || !app()->bound('UploadersRepository')) {
             return $entry;
         }
 
         $uploadDefinition = is_array($column[$macro]) ? $column[$macro] : [];
-        $uploaderClass    = $uploadDefinition['uploader'] ?? null;
+        $uploaderClass = $uploadDefinition['uploader'] ?? null;
 
         if ($uploaderClass === null) {
             $repository = app('UploadersRepository');
 
-            if (! $repository->hasUploadFor($column['type'], $macro)) {
+            if (!$repository->hasUploadFor($column['type'], $macro)) {
                 return $entry;
             }
 
@@ -53,7 +53,7 @@ class UploaderColumnHydrator
             $column['prefix'] = $uploader->getPath();
         }
         if (method_exists($uploader, 'useTemporaryUrl') && $uploader->useTemporaryUrl()) {
-            $column['temporary']  = true;
+            $column['temporary'] = true;
             $column['expiration'] = $uploader->getExpirationTimeInMinutes();
         }
 

--- a/src/app/Library/UploaderColumnHydrator.php
+++ b/src/app/Library/UploaderColumnHydrator.php
@@ -1,0 +1,86 @@
+<?php
+
+namespace Backpack\Settings\app\Library;
+
+use Illuminate\Database\Eloquent\Model;
+
+/**
+ * Resolves stored upload values into displayable form for a single Setting
+ * row, just before the list-view column is rendered.
+ *
+ * Why this exists: the normal Backpack upload pipeline relies on
+ * `CrudColumn::withFiles([...])` (or `->withMedia([...])`) being called
+ * inside `setupListOperation()`. That macro registers a `Model::retrieved`
+ * event that runs the configured uploader's `retrieveUploadedFiles()` to
+ * transform raw stored data (a path, a JSON array of paths, a media id,
+ * ...) into the URL the upload column view actually renders.
+ *
+ * In Settings we can't use that mechanism: every row is the SAME `Setting`
+ * model with the SAME column name (`value`), but each row may have a
+ * DIFFERENT uploader configuration. Registering one global retrieved event
+ * per row would make every uploader run against every row's value and the
+ * last one would win.
+ *
+ * So instead of registering events, we resolve the value per-row, on
+ * demand, against just the current entry — same call the event would make
+ * (`$uploader->retrieveUploadedFiles($entry)`), but scoped to one row.
+ */
+class UploaderColumnHydrator
+{
+    /**
+     * Column types this hydrator is allowed to act on.
+     */
+    protected const UPLOAD_COLUMN_TYPES = ['upload', 'upload_multiple', 'image'];
+
+    /**
+     * Resolve any uploader-managed value on $entry->{column['name']}
+     * in-place so the column view can render the URL(s).
+     *
+     * Safe no-op when:
+     *  - the column isn't an upload column type, or
+     *  - the column has no `withFiles` / `withMedia` definition, or
+     *  - the UploadersRepository / requested uploader isn't available
+     *    (e.g. medialibrary-uploaders not installed).
+     */
+    public static function hydrate(Model $entry, array $column): Model
+    {
+        if (! in_array($column['type'] ?? null, self::UPLOAD_COLUMN_TYPES, true)) {
+            return $entry;
+        }
+
+        // Find which uploader macro applies. Order matters: only one wins.
+        $macro = isset($column['withFiles']) ? 'withFiles'
+               : (isset($column['withMedia']) ? 'withMedia' : null);
+
+        if ($macro === null) {
+            return $entry;
+        }
+
+        // UploadersRepository is registered by backpack/crud's service
+        // provider. Bail out cleanly if the host app doesn't have it.
+        if (! app()->bound('UploadersRepository')) {
+            return $entry;
+        }
+
+        $uploadDefinition = is_array($column[$macro]) ? $column[$macro] : [];
+        $uploaderClass    = $uploadDefinition['uploader'] ?? null;
+
+        // If no custom uploader was provided, look up the default for this
+        // column type + macro pair (e.g. ['upload' => SingleFile::class]).
+        if ($uploaderClass === null) {
+            $repository = app('UploadersRepository');
+
+            if (! $repository->hasUploadFor($column['type'], $macro)) {
+                return $entry;
+            }
+
+            $uploaderClass = $repository->getUploadFor($column['type'], $macro);
+        }
+
+        // Build the uploader the same way RegisterUploadEvents does, but
+        // never register model events — we run it inline on this $entry.
+        $uploader = $uploaderClass::for($column, $uploadDefinition);
+
+        return $uploader->retrieveUploadedFiles($entry);
+    }
+}

--- a/src/app/Models/Setting.php
+++ b/src/app/Models/Setting.php
@@ -3,6 +3,7 @@
 namespace Backpack\Settings\app\Models;
 
 use Backpack\CRUD\app\Models\Traits\CrudTrait;
+use Backpack\Settings\SettingsServiceProvider;
 use Config;
 use Illuminate\Database\Eloquent\Model;
 
@@ -17,6 +18,12 @@ class Setting extends Model
         parent::__construct($attributes);
 
         $this->table = config('backpack.settings.table_name');
+    }
+
+    protected static function booted(): void
+    {
+        static::saved(fn () => SettingsServiceProvider::forgetCache());
+        static::deleted(fn () => SettingsServiceProvider::forgetCache());
     }
 
     /**

--- a/src/config/backpack/settings.php
+++ b/src/config/backpack/settings.php
@@ -49,6 +49,29 @@ return [
 
     /*
     |--------------------------------------------------------------------------
+    | Cache
+    |--------------------------------------------------------------------------
+    |
+    | Settings are loaded from the database on every request and bound to
+    | the Laravel config. To avoid hitting the DB on each request, the
+    | result is cached. The cache is automatically invalidated whenever a
+    | setting row is saved or deleted, so the TTL is just a safety net.
+    |
+    | Set `enabled` to false to disable caching entirely (useful in dev).
+    | Set `store` to null to use the default cache store, or to a specific
+    | store name (e.g. 'redis', 'file', 'array') from config/cache.php.
+    | `ttl` is in seconds; default is 30 days.
+    |
+    */
+    'cache' => [
+        'enabled' => true,
+        'store'   => null,
+        'key'     => 'backpack.settings.all',
+        'ttl'     => 60 * 60 * 24 * 30,
+    ],
+
+    /*
+    |--------------------------------------------------------------------------
     | Migration file name
     |--------------------------------------------------------------------------
     |

--- a/src/config/backpack/settings.php
+++ b/src/config/backpack/settings.php
@@ -57,4 +57,112 @@ return [
     |
     */
     'migration_name' => '2015_08_04_131614_create_settings_table',
+
+    /*
+    |--------------------------------------------------------------------------
+    | Column Migration file name
+    |--------------------------------------------------------------------------
+    |
+    | The file name for the migration that adds the optional `column` text
+    | field to the settings table. It allows defining how each setting's
+    | value is displayed in the list view, independent from how it's edited.
+    |
+    */
+    'column_migration_name' => '2026_05_29_000000_add_column_to_settings_table',
+
+    /*
+    |--------------------------------------------------------------------------
+    | Auto-resolve list columns from field definition
+    |--------------------------------------------------------------------------
+    |
+    | When `true`, the list view will format each setting's value cell
+    | according to the row's `field` JSON type (datetime fields render as
+    | formatted dates, checkbox fields as boolean icons, etc.) using the
+    | `field_to_column_map` below.
+    |
+    | When `false` (default), the value cell shows the raw stored value
+    | as plain text — this matches the legacy behavior of this package
+    | and is the safe default for upgrades, since auto-resolution can
+    | change the visual appearance of existing settings lists.
+    |
+    | Regardless of this flag, a setting row may always opt in on its own
+    | by storing an explicit column definition in its `column` DB field;
+    | that definition takes precedence over both auto-resolution and the
+    | plain-text fallback.
+    |
+    | This will default to `true` in the next major version.
+    |
+    */
+    'auto_resolve_columns' => false,
+
+    /*
+    |--------------------------------------------------------------------------
+    | Field-to-Column Type Map
+    |--------------------------------------------------------------------------
+    |
+    | When a setting row has no explicit `column` definition, the Settings
+    | package derives one from its `field` definition. This map controls how
+    | each Backpack field type is translated into a list-view column type.
+    |
+    | Set a type to `null` to fall back to the default ('text'). Add your
+    | own entries here to support custom field types or override the
+    | built-in defaults without forking the package.
+    |
+    */
+    'field_to_column_map' => [
+        // dates
+        'date'             => 'date',
+        'date_picker'      => 'date',
+        'datetime'         => 'datetime',
+        'datetime_picker'  => 'datetime',
+        'time'             => 'time',
+        'week'             => 'week',
+        'month'            => 'month',
+
+        // booleans
+        'checkbox'         => 'boolean',
+        'boolean'          => 'boolean',
+        'switch'           => 'boolean',
+
+        // selects
+        'select_from_array'        => 'select_from_array',
+        'enum'                     => 'enum',
+        'radio'                    => 'radio',
+        'select'                   => 'select',
+        'select2'                  => 'select',
+        'select_multiple'          => 'select_multiple',
+        'select2_multiple'         => 'select_multiple',
+        'select2_from_array'       => 'select_from_array',
+        'checklist'                => 'checklist',
+
+        // relationships (pro)
+        'relationship'             => 'relationship',
+        'repeatable'               => 'repeatable',
+
+        // media
+        'upload'           => 'upload',
+        'upload_multiple'  => 'upload_multiple',
+        'image'            => 'image',
+        'browse'           => 'upload',
+        'browse_multiple'  => 'upload_multiple',
+
+        // misc
+        'color'            => 'color',
+        'color_picker'     => 'color',
+        'number'           => 'number',
+        'range'            => 'number',
+        'email'            => 'email',
+        'url'              => 'url',
+        'phone'            => 'phone',
+        'password'         => 'password',
+        'textarea'         => 'textarea',
+        'tinymce'          => 'textarea',
+        'ckeditor'         => 'textarea',
+        'summernote'       => 'textarea',
+        'easymde'          => 'textarea',
+        'markdown'         => 'textarea',
+        'custom_html'      => 'custom_html',
+        'hidden'           => 'text',
+        'text'             => 'text',
+    ],
 ];

--- a/src/database/migrations/add_column_to_settings_table.php.stub
+++ b/src/database/migrations/add_column_to_settings_table.php.stub
@@ -1,0 +1,40 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class AddColumnToSettingsTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        $table = config('backpack.settings.table_name');
+
+        if (! Schema::hasColumn($table, 'column')) {
+            Schema::table($table, function (Blueprint $tbl) {
+                $tbl->text('column')->nullable()->after('field');
+            });
+        }
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        $table = config('backpack.settings.table_name');
+
+        if (Schema::hasColumn($table, 'column')) {
+            Schema::table($table, function (Blueprint $tbl) {
+                $tbl->dropColumn('column');
+            });
+        }
+    }
+}

--- a/src/database/migrations/create_settings_table.php.stub
+++ b/src/database/migrations/create_settings_table.php.stub
@@ -20,6 +20,7 @@ class CreateSettingsTable extends Migration
             $table->string('description')->nullable();
             $table->text('value')->nullable();
             $table->text('field');
+            $table->text('column')->nullable();
             $table->tinyInteger('active');
             $table->timestamps();
         });

--- a/src/resources/views/columns/setting_value.blade.php
+++ b/src/resources/views/columns/setting_value.blade.php
@@ -1,0 +1,72 @@
+{{-- 
+    Settings package: per-row column dispatcher.
+
+    Each setting row in the list defines its own value-cell rendering.
+    Resolution order:
+      1) If the row has a non-empty `column` JSON, use it verbatim.
+         (Always honored, regardless of the auto_resolve_columns flag.)
+      2) If `backpack.settings.auto_resolve_columns` is true, derive a
+         column definition from the row's `field` JSON via the
+         FieldToColumnResolver and the field_to_column_map config.
+      3) Otherwise, fall back to a plain text column (legacy behavior).
+--}}
+@php
+    $rowColumn = null;
+
+    // 1) explicit column definition on the row (always honored)
+    $explicit = $entry->getAttribute('column');
+    if (! empty($explicit)) {
+        $decoded = is_array($explicit) ? $explicit : json_decode($explicit, true);
+        if (is_array($decoded) && ! empty($decoded)) {
+            $rowColumn = $decoded;
+        }
+    }
+
+    // 2) derive from field definition (opt-in via config)
+    if ($rowColumn === null && config('backpack.settings.auto_resolve_columns', false)) {
+        $resolver = app(\Backpack\Settings\app\Library\FieldToColumnResolver::class);
+        $field = json_decode($entry->field ?? '{}', true);
+        $rowColumn = $resolver->resolve(is_array($field) ? $field : []);
+    }
+
+    // 3) safety net / legacy default
+    $rowColumn = $rowColumn ?: ['name' => 'value', 'type' => 'text'];
+
+    // force the column to point at the `value` attribute regardless of what
+    // was stored, since that's where the setting's value actually lives.
+    $rowColumn['name'] = 'value';
+
+    // copy display hints from the outer column so the developer can still
+    // tweak things like wrapper at the controller level if needed.
+    foreach (['wrapper', 'escaped', 'prefix', 'suffix'] as $k) {
+        if (! array_key_exists($k, $rowColumn) && array_key_exists($k, $column)) {
+            $rowColumn[$k] = $column[$k];
+        }
+    }
+
+    $resolvedType = $rowColumn['type'] ?? 'text';
+    $resolvedView = 'crud::columns.'.$resolvedType;
+
+    if (! view()->exists($resolvedView)) {
+        $resolvedView = 'crud::columns.text';
+    }
+
+    // If this row's column is an uploader-managed upload/image and carries
+    // a `withFiles` / `withMedia` definition, the raw `$entry->value` is
+    // still a stored path / json / media id. Resolve it to a URL per-row
+    // (we can't use the normal `Model::retrieved` event hookup because
+    // every Setting row shares the same model and `value` attribute, so
+    // a global event would let the last uploader win for every row).
+    $entry = \Backpack\Settings\app\Library\UploaderColumnHydrator::hydrate($entry, $rowColumn);
+
+    // expose the resolved column under the variable the built-in views expect
+    $originalColumn = $column;
+    $column = $rowColumn;
+@endphp
+
+@include($resolvedView, ['column' => $rowColumn, 'entry' => $entry, 'crud' => $crud])
+
+@php
+    // restore in case Backpack reuses $column further down the row
+    $column = $originalColumn;
+@endphp

--- a/src/resources/views/columns/setting_value.blade.php
+++ b/src/resources/views/columns/setting_value.blade.php
@@ -1,19 +1,12 @@
-{{-- 
-    Settings package: per-row column dispatcher.
-
-    Each setting row in the list defines its own value-cell rendering.
-    Resolution order:
-      1) If the row has a non-empty `column` JSON, use it verbatim.
-         (Always honored, regardless of the auto_resolve_columns flag.)
-      2) If `backpack.settings.auto_resolve_columns` is true, derive a
-         column definition from the row's `field` JSON via the
-         FieldToColumnResolver and the field_to_column_map config.
-      3) Otherwise, fall back to a plain text column (legacy behavior).
+{{--
+    Per-row column dispatcher. Resolution order for the value cell:
+      1. Explicit `column` JSON on the row (always honored).
+      2. Resolved from `field` JSON if `backpack.settings.auto_resolve_columns` is true.
+      3. Plain text column (legacy default).
 --}}
 @php
     $rowColumn = null;
 
-    // 1) explicit column definition on the row (always honored)
     $explicit = $entry->getAttribute('column');
     if (! empty($explicit)) {
         $decoded = is_array($explicit) ? $explicit : json_decode($explicit, true);
@@ -22,22 +15,15 @@
         }
     }
 
-    // 2) derive from field definition (opt-in via config)
     if ($rowColumn === null && config('backpack.settings.auto_resolve_columns', false)) {
         $resolver = app(\Backpack\Settings\app\Library\FieldToColumnResolver::class);
         $field = json_decode($entry->field ?? '{}', true);
         $rowColumn = $resolver->resolve(is_array($field) ? $field : []);
     }
 
-    // 3) safety net / legacy default
     $rowColumn = $rowColumn ?: ['name' => 'value', 'type' => 'text'];
-
-    // force the column to point at the `value` attribute regardless of what
-    // was stored, since that's where the setting's value actually lives.
     $rowColumn['name'] = 'value';
 
-    // copy display hints from the outer column so the developer can still
-    // tweak things like wrapper at the controller level if needed.
     foreach (['wrapper', 'escaped', 'prefix', 'suffix'] as $k) {
         if (! array_key_exists($k, $rowColumn) && array_key_exists($k, $column)) {
             $rowColumn[$k] = $column[$k];
@@ -51,15 +37,13 @@
         $resolvedView = 'crud::columns.text';
     }
 
-    // If this row's column is an uploader-managed upload/image and carries
-    // a `withFiles` / `withMedia` definition, the raw `$entry->value` is
-    // still a stored path / json / media id. Resolve it to a URL per-row
-    // (we can't use the normal `Model::retrieved` event hookup because
-    // every Setting row shares the same model and `value` attribute, so
-    // a global event would let the last uploader win for every row).
     $entry = \Backpack\Settings\app\Library\UploaderColumnHydrator::hydrate($entry, $rowColumn);
 
-    // expose the resolved column under the variable the built-in views expect
+    // Some column views (e.g. custom_html) don't fall back to data_get($entry, name).
+    if (! array_key_exists('value', $rowColumn)) {
+        $rowColumn['value'] = data_get($entry, $rowColumn['name']);
+    }
+
     $originalColumn = $column;
     $column = $rowColumn;
 @endphp
@@ -67,6 +51,5 @@
 @include($resolvedView, ['column' => $rowColumn, 'entry' => $entry, 'crud' => $crud])
 
 @php
-    // restore in case Backpack reuses $column further down the row
     $column = $originalColumn;
 @endphp

--- a/tests/FieldToColumnResolverTest.php
+++ b/tests/FieldToColumnResolverTest.php
@@ -14,24 +14,24 @@ class FieldToColumnResolverTest extends TestCase
     protected function map(): array
     {
         return [
-            'date'             => 'date',
-            'date_picker'      => 'date',
-            'datetime'         => 'datetime',
-            'datetime_picker'  => 'datetime',
-            'time'             => 'time',
-            'checkbox'         => 'boolean',
-            'switch'           => 'boolean',
+            'date'              => 'date',
+            'date_picker'       => 'date',
+            'datetime'          => 'datetime',
+            'datetime_picker'   => 'datetime',
+            'time'              => 'time',
+            'checkbox'          => 'boolean',
+            'switch'            => 'boolean',
             'select_from_array' => 'select_from_array',
-            'select'           => 'select',
-            'upload'           => 'upload',
-            'image'            => 'image',
-            'color'            => 'color',
-            'number'           => 'number',
-            'email'            => 'email',
-            'url'              => 'url',
-            'textarea'         => 'textarea',
-            'tinymce'          => 'textarea',
-            'text'             => 'text',
+            'select'            => 'select',
+            'upload'            => 'upload',
+            'image'             => 'image',
+            'color'             => 'color',
+            'number'            => 'number',
+            'email'             => 'email',
+            'url'               => 'url',
+            'textarea'          => 'textarea',
+            'tinymce'           => 'textarea',
+            'text'              => 'text',
         ];
     }
 
@@ -79,8 +79,8 @@ class FieldToColumnResolverTest extends TestCase
     public function test_it_promotes_datetime_picker_display_format_to_column_format()
     {
         $column = $this->resolver()->resolve([
-            'name' => 'value',
-            'type' => 'datetime_picker',
+            'name'                    => 'value',
+            'type'                    => 'datetime_picker',
             'datetime_picker_options' => [
                 'displayFormat' => 'M/D/YY h:mm A',
                 'format'        => 'YYYY-MM-DD HH:mm:ss',
@@ -94,9 +94,9 @@ class FieldToColumnResolverTest extends TestCase
     public function test_explicit_field_format_wins_over_picker_display_format()
     {
         $column = $this->resolver()->resolve([
-            'name'   => 'value',
-            'type'   => 'datetime_picker',
-            'format' => 'DD/MM/YYYY',
+            'name'                    => 'value',
+            'type'                    => 'datetime_picker',
+            'format'                  => 'DD/MM/YYYY',
             'datetime_picker_options' => ['displayFormat' => 'M/D/YY h:mm A'],
         ]);
 
@@ -261,8 +261,8 @@ class FieldToColumnResolverTest extends TestCase
     public function test_it_strips_picker_options_after_harvesting_format()
     {
         $column = $this->resolver()->resolve([
-            'name' => 'value',
-            'type' => 'datetime_picker',
+            'name'                    => 'value',
+            'type'                    => 'datetime_picker',
             'datetime_picker_options' => ['displayFormat' => 'M/D/YY h:mm A'],
         ]);
 

--- a/tests/FieldToColumnResolverTest.php
+++ b/tests/FieldToColumnResolverTest.php
@@ -1,0 +1,377 @@
+<?php
+
+namespace Backpack\Settings\Test;
+
+use Backpack\Settings\app\Library\FieldToColumnResolver;
+use PHPUnit\Framework\TestCase;
+
+class FieldToColumnResolverTest extends TestCase
+{
+    /**
+     * Default field-to-column map used in tests. Mirrors the package's
+     * shipped config so tests are independent from Laravel's container.
+     */
+    protected function map(): array
+    {
+        return [
+            'date'             => 'date',
+            'date_picker'      => 'date',
+            'datetime'         => 'datetime',
+            'datetime_picker'  => 'datetime',
+            'time'             => 'time',
+            'checkbox'         => 'boolean',
+            'switch'           => 'boolean',
+            'select_from_array' => 'select_from_array',
+            'select'           => 'select',
+            'upload'           => 'upload',
+            'image'            => 'image',
+            'color'            => 'color',
+            'number'           => 'number',
+            'email'            => 'email',
+            'url'              => 'url',
+            'textarea'         => 'textarea',
+            'tinymce'          => 'textarea',
+            'text'             => 'text',
+        ];
+    }
+
+    protected function resolver(): FieldToColumnResolver
+    {
+        return new FieldToColumnResolver($this->map());
+    }
+
+    public function test_it_defaults_to_text_when_field_is_null()
+    {
+        $column = $this->resolver()->resolve(null);
+
+        $this->assertSame('value', $column['name']);
+        $this->assertSame('text', $column['type']);
+    }
+
+    public function test_it_defaults_to_text_when_field_is_empty()
+    {
+        $column = $this->resolver()->resolve([]);
+
+        $this->assertSame('text', $column['type']);
+    }
+
+    public function test_it_falls_back_to_text_for_unknown_field_types()
+    {
+        $column = $this->resolver()->resolve(['type' => 'totally_made_up']);
+
+        $this->assertSame('text', $column['type']);
+    }
+
+    public function test_it_maps_datetime_field_to_datetime_column()
+    {
+        $column = $this->resolver()->resolve([
+            'name'   => 'value',
+            'label'  => 'Last Incident',
+            'type'   => 'datetime',
+            'format' => 'YYYY-MM-DD HH:mm:ss',
+        ]);
+
+        $this->assertSame('datetime', $column['type']);
+        $this->assertSame('YYYY-MM-DD HH:mm:ss', $column['format']);
+        $this->assertSame('Last Incident', $column['label']);
+    }
+
+    public function test_it_promotes_datetime_picker_display_format_to_column_format()
+    {
+        $column = $this->resolver()->resolve([
+            'name' => 'value',
+            'type' => 'datetime_picker',
+            'datetime_picker_options' => [
+                'displayFormat' => 'M/D/YY h:mm A',
+                'format'        => 'YYYY-MM-DD HH:mm:ss',
+            ],
+        ]);
+
+        $this->assertSame('datetime', $column['type']);
+        $this->assertSame('M/D/YY h:mm A', $column['format']);
+    }
+
+    public function test_explicit_field_format_wins_over_picker_display_format()
+    {
+        $column = $this->resolver()->resolve([
+            'name'   => 'value',
+            'type'   => 'datetime_picker',
+            'format' => 'DD/MM/YYYY',
+            'datetime_picker_options' => ['displayFormat' => 'M/D/YY h:mm A'],
+        ]);
+
+        $this->assertSame('DD/MM/YYYY', $column['format']);
+    }
+
+    public function test_it_maps_checkbox_to_boolean()
+    {
+        $column = $this->resolver()->resolve(['type' => 'checkbox']);
+
+        $this->assertSame('boolean', $column['type']);
+    }
+
+    public function test_it_forwards_options_for_select_from_array()
+    {
+        $column = $this->resolver()->resolve([
+            'name'    => 'value',
+            'type'    => 'select_from_array',
+            'options' => ['a' => 'A', 'b' => 'B'],
+        ]);
+
+        $this->assertSame('select_from_array', $column['type']);
+        $this->assertSame(['a' => 'A', 'b' => 'B'], $column['options']);
+    }
+
+    public function test_it_forwards_disk_for_upload()
+    {
+        $column = $this->resolver()->resolve([
+            'name' => 'value',
+            'type' => 'upload',
+            'disk' => 'public',
+        ]);
+
+        $this->assertSame('upload', $column['type']);
+        $this->assertSame('public', $column['disk']);
+    }
+
+    /**
+     * The `upload` column also reads `temporary`, `expiration` and `prefix`.
+     * Verify they all flow through.
+     */
+    public function test_it_forwards_all_upload_column_attributes()
+    {
+        $column = $this->resolver()->resolve([
+            'name'       => 'value',
+            'type'       => 'upload',
+            'disk'       => 's3',
+            'prefix'     => 'uploads/',
+            'temporary'  => 30,
+            'expiration' => 60,
+        ]);
+
+        $this->assertSame('s3', $column['disk']);
+        $this->assertSame('uploads/', $column['prefix']);
+        $this->assertSame(30, $column['temporary']);
+        $this->assertSame(60, $column['expiration']);
+    }
+
+    /**
+     * The `image` column uses `height`, `width`, `radius`, `prefix`,
+     * `disk`, `temporary`, `expiration`. Verify they all flow through.
+     */
+    public function test_it_forwards_all_image_column_attributes()
+    {
+        $resolver = new FieldToColumnResolver($this->map() + ['image' => 'image']);
+
+        $column = $resolver->resolve([
+            'name'       => 'value',
+            'type'       => 'image',
+            'disk'       => 'public',
+            'prefix'     => 'images/',
+            'height'     => '50px',
+            'width'      => '80px',
+            'radius'     => '8px',
+            'temporary'  => 10,
+            'expiration' => 5,
+        ]);
+
+        $this->assertSame('image', $column['type']);
+        $this->assertSame('50px', $column['height']);
+        $this->assertSame('80px', $column['width']);
+        $this->assertSame('8px', $column['radius']);
+        $this->assertSame(10, $column['temporary']);
+        $this->assertSame(5, $column['expiration']);
+    }
+
+    /**
+     * `withFiles` and `withMedia` are uploader macros registered on BOTH
+     * CrudField and CrudColumn (see backpack/crud/src/macros.php and
+     * backpack/medialibrary-uploaders). They store the upload definition
+     * and register the events that hydrate stored values for display, so
+     * they MUST flow through to the column definition unchanged.
+     */
+    public function test_it_forwards_uploader_macros_to_column()
+    {
+        $withFiles = ['disk' => 'public', 'path' => 'settings'];
+        $withMedia = ['disk' => 'media', 'collection' => 'settings'];
+
+        $column = $this->resolver()->resolve([
+            'name'      => 'value',
+            'type'      => 'upload',
+            'disk'      => 'public',
+            'withFiles' => $withFiles,
+            'withMedia' => $withMedia,
+        ]);
+
+        $this->assertSame($withFiles, $column['withFiles']);
+        $this->assertSame($withMedia, $column['withMedia']);
+        $this->assertSame('public', $column['disk']);
+    }
+
+    /**
+     * Form-only keys (attributes, hint, view_namespace, tab, validation,
+     * wrapperAttributes, fake, etc.) must NOT leak onto the column
+     * definition, since they have different semantics there and would
+     * break the list view (e.g. `attributes` is an HTML input attrs array
+     * on fields, and `view_namespace` would point at a *field* view path).
+     */
+    public function test_it_strips_form_only_attributes()
+    {
+        $column = $this->resolver()->resolve([
+            'name'                  => 'value',
+            'type'                  => 'datetime',
+            'format'                => 'YYYY-MM-DD',
+            'attributes'            => ['class' => 'form-control-lg'],
+            'wrapperAttributes'     => ['class' => 'col-md-6'],
+            'hint'                  => 'Pick a date',
+            'view_namespace'        => 'custom.fields',
+            'tab'                   => 'Dates',
+            'validation'            => 'required',
+            'validationRules'       => 'required',
+            'validationMessages'    => ['required' => 'nope'],
+            'fake'                  => true,
+            'store_in'              => 'extras',
+            'dependencies'          => ['other_field'],
+            'on_change'             => 'doSomething()',
+            'inline_create'         => true,
+            'ajax'                  => true,
+            'minimum_input_length'  => 2,
+            'placeholder'           => 'Pick one',
+            'readonly'              => true,
+            'disabled'              => true,
+            'autocomplete'          => 'off',
+            'allows_null'           => true,
+            'allows_multiple'       => false,
+            'pivotSelect'           => ['type' => 'select'],
+            'force_select'          => true,
+        ]);
+
+        foreach ([
+            'attributes', 'wrapperAttributes', 'hint', 'view_namespace',
+            'tab', 'validation', 'validationRules', 'validationMessages',
+            'fake', 'store_in', 'dependencies', 'on_change',
+            'inline_create', 'ajax', 'minimum_input_length', 'placeholder',
+            'readonly', 'disabled', 'autocomplete',
+            'allows_null', 'allows_multiple', 'pivotSelect', 'force_select',
+        ] as $k) {
+            $this->assertArrayNotHasKey($k, $column, "Form-only key `$k` leaked onto column");
+        }
+    }
+
+    public function test_it_strips_picker_options_after_harvesting_format()
+    {
+        $column = $this->resolver()->resolve([
+            'name' => 'value',
+            'type' => 'datetime_picker',
+            'datetime_picker_options' => ['displayFormat' => 'M/D/YY h:mm A'],
+        ]);
+
+        $this->assertSame('M/D/YY h:mm A', $column['format']);
+        $this->assertArrayNotHasKey('datetime_picker_options', $column);
+    }
+
+    /**
+     * `subfields` IS a valid column attribute on `repeatable`, `relationship`
+     * and `checklist_dependency` columns (used by Backpack PRO). It must be
+     * forwarded to the column definition.
+     */
+    public function test_it_passes_through_subfields_for_repeatable_like_columns()
+    {
+        $subfields = [
+            ['name' => 'street', 'type' => 'text'],
+            ['name' => 'city',   'type' => 'text'],
+        ];
+
+        $resolver = new FieldToColumnResolver($this->map() + ['repeatable' => 'repeatable']);
+
+        $column = $resolver->resolve([
+            'name'      => 'value',
+            'type'      => 'repeatable',
+            'subfields' => $subfields,
+        ]);
+
+        $this->assertSame('repeatable', $column['type']);
+        $this->assertSame($subfields, $column['subfields']);
+    }
+
+    public function test_it_passes_through_relationship_attributes()
+    {
+        $resolver = new FieldToColumnResolver($this->map() + ['relationship' => 'relationship']);
+
+        $column = $resolver->resolve([
+            'name'          => 'value',
+            'type'          => 'relationship',
+            'entity'        => 'category',
+            'attribute'     => 'name',
+            'model'         => 'App\\Models\\Category',
+            'relation_type' => 'BelongsTo',
+            'pivot'         => false,
+            'key'           => 'category_id',
+        ]);
+
+        $this->assertSame('relationship', $column['type']);
+        $this->assertSame('category', $column['entity']);
+        $this->assertSame('name', $column['attribute']);
+        $this->assertSame('App\\Models\\Category', $column['model']);
+        $this->assertSame('BelongsTo', $column['relation_type']);
+        $this->assertFalse($column['pivot']);
+        $this->assertSame('category_id', $column['key']);
+    }
+
+    public function test_it_passes_through_safe_display_keys()
+    {
+        $column = $this->resolver()->resolve([
+            'name'    => 'value',
+            'type'    => 'text',
+            'prefix'  => '$',
+            'suffix'  => ' USD',
+            'default' => 'n/a',
+            'wrapper' => ['element' => 'a', 'href' => '#'],
+            'escaped' => false,
+            'limit'   => 100,
+        ]);
+
+        $this->assertSame('$', $column['prefix']);
+        $this->assertSame(' USD', $column['suffix']);
+        $this->assertSame('n/a', $column['default']);
+        $this->assertSame(['element' => 'a', 'href' => '#'], $column['wrapper']);
+        $this->assertFalse($column['escaped']);
+        $this->assertSame(100, $column['limit']);
+    }
+
+    public function test_user_can_override_map_via_constructor()
+    {
+        $resolver = new FieldToColumnResolver([
+            'my_custom_field' => 'my_custom_column',
+        ]);
+
+        $column = $resolver->resolve(['type' => 'my_custom_field']);
+
+        $this->assertSame('my_custom_column', $column['type']);
+    }
+
+    /**
+     * The blacklist approach means any field key NOT on the strip list flows
+     * through. This is the whole point: future column types and per-type
+     * attributes work automatically without us having to update a whitelist.
+     */
+    public function test_unknown_attributes_flow_through_to_column()
+    {
+        $column = $this->resolver()->resolve([
+            'name'              => 'value',
+            'type'              => 'text',
+            'some_future_attr'  => 'foo',
+            'another_one'       => ['nested' => true],
+        ]);
+
+        $this->assertSame('foo', $column['some_future_attr']);
+        $this->assertSame(['nested' => true], $column['another_one']);
+    }
+
+    public function test_it_defaults_column_name_to_value_when_field_has_no_name()
+    {
+        $column = $this->resolver()->resolve(['type' => 'text']);
+
+        $this->assertSame('value', $column['name']);
+    }
+}

--- a/tests/UploaderColumnHydratorTest.php
+++ b/tests/UploaderColumnHydratorTest.php
@@ -1,0 +1,227 @@
+<?php
+
+namespace Backpack\Settings\Test;
+
+use Backpack\Settings\app\Library\UploaderColumnHydrator;
+use Illuminate\Container\Container;
+use Illuminate\Database\Eloquent\Model;
+use PHPUnit\Framework\TestCase;
+
+class UploaderColumnHydratorTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        // Fresh container per test so the bound `UploadersRepository`
+        // doesn't leak between cases.
+        Container::setInstance(new Container);
+    }
+
+    protected function tearDown(): void
+    {
+        Container::setInstance(null);
+        FakeUploadersRepository::$calls = [];
+        FakeSettingsUploader::$calls = [];
+
+        parent::tearDown();
+    }
+
+    public function test_it_is_a_noop_for_non_upload_column_types()
+    {
+        $entry = new FakeSettingEntry(['value' => 'raw']);
+
+        $result = UploaderColumnHydrator::hydrate($entry, [
+            'name' => 'value',
+            'type' => 'text',
+        ]);
+
+        $this->assertSame('raw', $result->value);
+    }
+
+    public function test_it_is_a_noop_when_no_uploader_macro_is_present()
+    {
+        $entry = new FakeSettingEntry(['value' => 'foo/bar.jpg']);
+
+        $result = UploaderColumnHydrator::hydrate($entry, [
+            'name' => 'value',
+            'type' => 'upload',
+            'disk' => 'public',
+        ]);
+
+        $this->assertSame('foo/bar.jpg', $result->value);
+    }
+
+    public function test_it_is_a_noop_when_uploaders_repository_is_not_bound()
+    {
+        // Container is fresh + empty; no UploadersRepository registered.
+        $entry = new FakeSettingEntry(['value' => 'foo/bar.jpg']);
+
+        $result = UploaderColumnHydrator::hydrate($entry, [
+            'name'      => 'value',
+            'type'      => 'upload',
+            'withFiles' => ['disk' => 'public'],
+        ]);
+
+        $this->assertSame('foo/bar.jpg', $result->value);
+    }
+
+    public function test_it_is_a_noop_when_no_uploader_is_registered_for_the_column_type_and_macro()
+    {
+        Container::getInstance()->instance('UploadersRepository', new FakeUploadersRepository([]));
+
+        $entry = new FakeSettingEntry(['value' => 'foo/bar.jpg']);
+
+        $result = UploaderColumnHydrator::hydrate($entry, [
+            'name'      => 'value',
+            'type'      => 'upload',
+            'withFiles' => ['disk' => 'public'],
+        ]);
+
+        $this->assertSame('foo/bar.jpg', $result->value);
+    }
+
+    public function test_it_runs_the_default_uploader_for_with_files_and_hydrates_the_value()
+    {
+        Container::getInstance()->instance('UploadersRepository', new FakeUploadersRepository([
+            'upload|withFiles' => FakeSettingsUploader::class,
+        ]));
+
+        $entry = new FakeSettingEntry(['value' => 'logo.png']);
+
+        $result = UploaderColumnHydrator::hydrate($entry, [
+            'name'      => 'value',
+            'type'      => 'upload',
+            'withFiles' => ['disk' => 'public', 'path' => 'settings'],
+        ]);
+
+        $this->assertSame('hydrated:logo.png', $result->value);
+        $this->assertCount(1, FakeSettingsUploader::$calls);
+        $this->assertSame(
+            ['disk' => 'public', 'path' => 'settings'],
+            FakeSettingsUploader::$calls[0]['uploadDefinition']
+        );
+    }
+
+    public function test_it_runs_the_default_uploader_for_with_media()
+    {
+        Container::getInstance()->instance('UploadersRepository', new FakeUploadersRepository([
+            'image|withMedia' => FakeSettingsUploader::class,
+        ]));
+
+        $entry = new FakeSettingEntry(['value' => 'avatar.jpg']);
+
+        $result = UploaderColumnHydrator::hydrate($entry, [
+            'name'      => 'value',
+            'type'      => 'image',
+            'withMedia' => ['collection' => 'settings'],
+        ]);
+
+        $this->assertSame('hydrated:avatar.jpg', $result->value);
+    }
+
+    public function test_it_honors_a_custom_uploader_class_from_the_definition()
+    {
+        // Even with NO default registered, an explicit `uploader` key wins.
+        Container::getInstance()->instance('UploadersRepository', new FakeUploadersRepository([]));
+
+        $entry = new FakeSettingEntry(['value' => 'doc.pdf']);
+
+        $result = UploaderColumnHydrator::hydrate($entry, [
+            'name'      => 'value',
+            'type'      => 'upload',
+            'withFiles' => [
+                'uploader' => FakeSettingsUploader::class,
+                'disk'     => 'private',
+            ],
+        ]);
+
+        $this->assertSame('hydrated:doc.pdf', $result->value);
+    }
+
+    public function test_with_files_wins_when_both_macros_are_present()
+    {
+        Container::getInstance()->instance('UploadersRepository', new FakeUploadersRepository([
+            'upload|withFiles' => FakeSettingsUploader::class,
+            'upload|withMedia' => FakeSettingsAlternateUploader::class,
+        ]));
+
+        $entry = new FakeSettingEntry(['value' => 'x.png']);
+
+        UploaderColumnHydrator::hydrate($entry, [
+            'name'      => 'value',
+            'type'      => 'upload',
+            'withFiles' => ['disk' => 'a'],
+            'withMedia' => ['disk' => 'b'],
+        ]);
+
+        $this->assertCount(1, FakeSettingsUploader::$calls);
+        $this->assertCount(0, FakeSettingsAlternateUploader::$calls);
+    }
+}
+
+/**
+ * Minimal Eloquent stand-in. We only need property access on `value` —
+ * the hydrator never touches relations / casts / persistence.
+ */
+class FakeSettingEntry extends Model
+{
+    protected $guarded = [];
+}
+
+class FakeUploadersRepository
+{
+    public static array $calls = [];
+
+    public function __construct(private array $map = []) {}
+
+    public function hasUploadFor($type, $macro): bool
+    {
+        return isset($this->map[$type.'|'.$macro]);
+    }
+
+    public function getUploadFor($type, $macro): string
+    {
+        return $this->map[$type.'|'.$macro];
+    }
+}
+
+class FakeSettingsUploader
+{
+    public static array $calls = [];
+
+    public function __construct(public array $crudObject, public array $uploadDefinition) {}
+
+    public static function for(array $crudObject, array $uploadDefinition): self
+    {
+        self::$calls[] = compact('crudObject', 'uploadDefinition');
+
+        return new self($crudObject, $uploadDefinition);
+    }
+
+    public function retrieveUploadedFiles(Model $entry): Model
+    {
+        $entry->value = 'hydrated:'.$entry->value;
+
+        return $entry;
+    }
+}
+
+class FakeSettingsAlternateUploader extends FakeSettingsUploader
+{
+    public static array $calls = [];
+
+    public static function for(array $crudObject, array $uploadDefinition): self
+    {
+        self::$calls[] = compact('crudObject', 'uploadDefinition');
+
+        return new self($crudObject, $uploadDefinition);
+    }
+
+    public function retrieveUploadedFiles(Model $entry): Model
+    {
+        $entry->value = 'alt:'.$entry->value;
+
+        return $entry;
+    }
+}

--- a/tests/UploaderColumnHydratorTest.php
+++ b/tests/UploaderColumnHydratorTest.php
@@ -15,7 +15,7 @@ class UploaderColumnHydratorTest extends TestCase
 
         // Fresh container per test so the bound `UploadersRepository`
         // doesn't leak between cases.
-        Container::setInstance(new Container);
+        Container::setInstance(new Container());
     }
 
     protected function tearDown(): void
@@ -29,7 +29,7 @@ class UploaderColumnHydratorTest extends TestCase
 
     public function test_it_is_a_noop_for_non_upload_column_types()
     {
-        $entry  = new FakeSettingEntry(['value' => 'raw']);
+        $entry = new FakeSettingEntry(['value' => 'raw']);
         $column = ['name' => 'value', 'type' => 'text'];
 
         $result = UploaderColumnHydrator::hydrate($entry, $column);
@@ -40,7 +40,7 @@ class UploaderColumnHydratorTest extends TestCase
 
     public function test_it_is_a_noop_when_no_uploader_macro_is_present()
     {
-        $entry  = new FakeSettingEntry(['value' => 'foo/bar.jpg']);
+        $entry = new FakeSettingEntry(['value' => 'foo/bar.jpg']);
         $column = ['name' => 'value', 'type' => 'upload', 'disk' => 'public'];
 
         $result = UploaderColumnHydrator::hydrate($entry, $column);
@@ -52,7 +52,7 @@ class UploaderColumnHydratorTest extends TestCase
     public function test_it_is_a_noop_when_uploaders_repository_is_not_bound()
     {
         // Container is fresh + empty; no UploadersRepository registered.
-        $entry  = new FakeSettingEntry(['value' => 'foo/bar.jpg']);
+        $entry = new FakeSettingEntry(['value' => 'foo/bar.jpg']);
         $column = ['name' => 'value', 'type' => 'upload', 'withFiles' => ['disk' => 'public']];
 
         $result = UploaderColumnHydrator::hydrate($entry, $column);
@@ -64,7 +64,7 @@ class UploaderColumnHydratorTest extends TestCase
     {
         Container::getInstance()->instance('UploadersRepository', new FakeUploadersRepository([]));
 
-        $entry  = new FakeSettingEntry(['value' => 'foo/bar.jpg']);
+        $entry = new FakeSettingEntry(['value' => 'foo/bar.jpg']);
         $column = ['name' => 'value', 'type' => 'upload', 'withFiles' => ['disk' => 'public']];
 
         $result = UploaderColumnHydrator::hydrate($entry, $column);
@@ -78,7 +78,7 @@ class UploaderColumnHydratorTest extends TestCase
             'upload|withFiles' => FakeSettingsUploader::class,
         ]));
 
-        $entry  = new FakeSettingEntry(['value' => 'logo.png']);
+        $entry = new FakeSettingEntry(['value' => 'logo.png']);
         $column = [
             'name'      => 'value',
             'type'      => 'upload',
@@ -108,7 +108,7 @@ class UploaderColumnHydratorTest extends TestCase
             'upload|withFiles' => FakeSettingsUploader::class,
         ]));
 
-        $entry  = new FakeSettingEntry(['value' => 'logo.png']);
+        $entry = new FakeSettingEntry(['value' => 'logo.png']);
         $column = [
             'name'      => 'value',
             'type'      => 'upload',
@@ -127,7 +127,7 @@ class UploaderColumnHydratorTest extends TestCase
             'upload|withFiles' => FakeTemporaryUrlUploader::class,
         ]));
 
-        $entry  = new FakeSettingEntry(['value' => 'logo.png']);
+        $entry = new FakeSettingEntry(['value' => 'logo.png']);
         $column = [
             'name'      => 'value',
             'type'      => 'upload',
@@ -146,7 +146,7 @@ class UploaderColumnHydratorTest extends TestCase
             'image|withMedia' => FakeSettingsUploader::class,
         ]));
 
-        $entry  = new FakeSettingEntry(['value' => 'avatar.jpg']);
+        $entry = new FakeSettingEntry(['value' => 'avatar.jpg']);
         $column = [
             'name'      => 'value',
             'type'      => 'image',
@@ -163,7 +163,7 @@ class UploaderColumnHydratorTest extends TestCase
         // Even with NO default registered, an explicit `uploader` key wins.
         Container::getInstance()->instance('UploadersRepository', new FakeUploadersRepository([]));
 
-        $entry  = new FakeSettingEntry(['value' => 'doc.pdf']);
+        $entry = new FakeSettingEntry(['value' => 'doc.pdf']);
         $column = [
             'name'      => 'value',
             'type'      => 'upload',
@@ -185,7 +185,7 @@ class UploaderColumnHydratorTest extends TestCase
             'upload|withMedia' => FakeSettingsAlternateUploader::class,
         ]));
 
-        $entry  = new FakeSettingEntry(['value' => 'x.png']);
+        $entry = new FakeSettingEntry(['value' => 'x.png']);
         $column = [
             'name'      => 'value',
             'type'      => 'upload',
@@ -211,7 +211,9 @@ class FakeSettingEntry extends Model
 
 class FakeUploadersRepository
 {
-    public function __construct(private array $map = []) {}
+    public function __construct(private array $map = [])
+    {
+    }
 
     public function hasUploadFor($type, $macro): bool
     {
@@ -228,7 +230,9 @@ class FakeSettingsUploader
 {
     public static array $calls = [];
 
-    public function __construct(public array $crudObject, public array $uploadDefinition) {}
+    public function __construct(public array $crudObject, public array $uploadDefinition)
+    {
+    }
 
     public static function for(array $crudObject, array $uploadDefinition): self
     {

--- a/tests/UploaderColumnHydratorTest.php
+++ b/tests/UploaderColumnHydratorTest.php
@@ -21,47 +21,41 @@ class UploaderColumnHydratorTest extends TestCase
     protected function tearDown(): void
     {
         Container::setInstance(null);
-        FakeUploadersRepository::$calls = [];
         FakeSettingsUploader::$calls = [];
+        FakeSettingsAlternateUploader::$calls = [];
 
         parent::tearDown();
     }
 
     public function test_it_is_a_noop_for_non_upload_column_types()
     {
-        $entry = new FakeSettingEntry(['value' => 'raw']);
+        $entry  = new FakeSettingEntry(['value' => 'raw']);
+        $column = ['name' => 'value', 'type' => 'text'];
 
-        $result = UploaderColumnHydrator::hydrate($entry, [
-            'name' => 'value',
-            'type' => 'text',
-        ]);
+        $result = UploaderColumnHydrator::hydrate($entry, $column);
 
         $this->assertSame('raw', $result->value);
+        $this->assertArrayNotHasKey('disk', $column);
     }
 
     public function test_it_is_a_noop_when_no_uploader_macro_is_present()
     {
-        $entry = new FakeSettingEntry(['value' => 'foo/bar.jpg']);
+        $entry  = new FakeSettingEntry(['value' => 'foo/bar.jpg']);
+        $column = ['name' => 'value', 'type' => 'upload', 'disk' => 'public'];
 
-        $result = UploaderColumnHydrator::hydrate($entry, [
-            'name' => 'value',
-            'type' => 'upload',
-            'disk' => 'public',
-        ]);
+        $result = UploaderColumnHydrator::hydrate($entry, $column);
 
         $this->assertSame('foo/bar.jpg', $result->value);
+        $this->assertSame('public', $column['disk']);
     }
 
     public function test_it_is_a_noop_when_uploaders_repository_is_not_bound()
     {
         // Container is fresh + empty; no UploadersRepository registered.
-        $entry = new FakeSettingEntry(['value' => 'foo/bar.jpg']);
+        $entry  = new FakeSettingEntry(['value' => 'foo/bar.jpg']);
+        $column = ['name' => 'value', 'type' => 'upload', 'withFiles' => ['disk' => 'public']];
 
-        $result = UploaderColumnHydrator::hydrate($entry, [
-            'name'      => 'value',
-            'type'      => 'upload',
-            'withFiles' => ['disk' => 'public'],
-        ]);
+        $result = UploaderColumnHydrator::hydrate($entry, $column);
 
         $this->assertSame('foo/bar.jpg', $result->value);
     }
@@ -70,13 +64,10 @@ class UploaderColumnHydratorTest extends TestCase
     {
         Container::getInstance()->instance('UploadersRepository', new FakeUploadersRepository([]));
 
-        $entry = new FakeSettingEntry(['value' => 'foo/bar.jpg']);
+        $entry  = new FakeSettingEntry(['value' => 'foo/bar.jpg']);
+        $column = ['name' => 'value', 'type' => 'upload', 'withFiles' => ['disk' => 'public']];
 
-        $result = UploaderColumnHydrator::hydrate($entry, [
-            'name'      => 'value',
-            'type'      => 'upload',
-            'withFiles' => ['disk' => 'public'],
-        ]);
+        $result = UploaderColumnHydrator::hydrate($entry, $column);
 
         $this->assertSame('foo/bar.jpg', $result->value);
     }
@@ -87,13 +78,14 @@ class UploaderColumnHydratorTest extends TestCase
             'upload|withFiles' => FakeSettingsUploader::class,
         ]));
 
-        $entry = new FakeSettingEntry(['value' => 'logo.png']);
-
-        $result = UploaderColumnHydrator::hydrate($entry, [
+        $entry  = new FakeSettingEntry(['value' => 'logo.png']);
+        $column = [
             'name'      => 'value',
             'type'      => 'upload',
             'withFiles' => ['disk' => 'public', 'path' => 'settings'],
-        ]);
+        ];
+
+        $result = UploaderColumnHydrator::hydrate($entry, $column);
 
         $this->assertSame('hydrated:logo.png', $result->value);
         $this->assertCount(1, FakeSettingsUploader::$calls);
@@ -103,19 +95,65 @@ class UploaderColumnHydratorTest extends TestCase
         );
     }
 
+    /**
+     * Regression: the upload column blade view reads `$column['disk']` and
+     * `$column['prefix']` directly. If the hydrator only mutates $entry and
+     * leaves the column untouched, the view crashes with
+     * "Undefined array key 'disk'". RegisterUploadEvents normally sets
+     * these via setupUploadConfigsInCrudObject() — the hydrator must too.
+     */
+    public function test_it_populates_disk_and_prefix_on_the_column_from_the_uploader()
+    {
+        Container::getInstance()->instance('UploadersRepository', new FakeUploadersRepository([
+            'upload|withFiles' => FakeSettingsUploader::class,
+        ]));
+
+        $entry  = new FakeSettingEntry(['value' => 'logo.png']);
+        $column = [
+            'name'      => 'value',
+            'type'      => 'upload',
+            'withFiles' => ['disk' => 'public', 'path' => 'settings'],
+        ];
+
+        UploaderColumnHydrator::hydrate($entry, $column);
+
+        $this->assertSame('public', $column['disk']);
+        $this->assertSame('settings', $column['prefix']);
+    }
+
+    public function test_it_populates_temporary_and_expiration_when_the_uploader_uses_temporary_urls()
+    {
+        Container::getInstance()->instance('UploadersRepository', new FakeUploadersRepository([
+            'upload|withFiles' => FakeTemporaryUrlUploader::class,
+        ]));
+
+        $entry  = new FakeSettingEntry(['value' => 'logo.png']);
+        $column = [
+            'name'      => 'value',
+            'type'      => 'upload',
+            'withFiles' => ['disk' => 'private', 'temporaryUrl' => true],
+        ];
+
+        UploaderColumnHydrator::hydrate($entry, $column);
+
+        $this->assertTrue($column['temporary']);
+        $this->assertSame(15, $column['expiration']);
+    }
+
     public function test_it_runs_the_default_uploader_for_with_media()
     {
         Container::getInstance()->instance('UploadersRepository', new FakeUploadersRepository([
             'image|withMedia' => FakeSettingsUploader::class,
         ]));
 
-        $entry = new FakeSettingEntry(['value' => 'avatar.jpg']);
-
-        $result = UploaderColumnHydrator::hydrate($entry, [
+        $entry  = new FakeSettingEntry(['value' => 'avatar.jpg']);
+        $column = [
             'name'      => 'value',
             'type'      => 'image',
             'withMedia' => ['collection' => 'settings'],
-        ]);
+        ];
+
+        $result = UploaderColumnHydrator::hydrate($entry, $column);
 
         $this->assertSame('hydrated:avatar.jpg', $result->value);
     }
@@ -125,16 +163,17 @@ class UploaderColumnHydratorTest extends TestCase
         // Even with NO default registered, an explicit `uploader` key wins.
         Container::getInstance()->instance('UploadersRepository', new FakeUploadersRepository([]));
 
-        $entry = new FakeSettingEntry(['value' => 'doc.pdf']);
-
-        $result = UploaderColumnHydrator::hydrate($entry, [
+        $entry  = new FakeSettingEntry(['value' => 'doc.pdf']);
+        $column = [
             'name'      => 'value',
             'type'      => 'upload',
             'withFiles' => [
                 'uploader' => FakeSettingsUploader::class,
                 'disk'     => 'private',
             ],
-        ]);
+        ];
+
+        $result = UploaderColumnHydrator::hydrate($entry, $column);
 
         $this->assertSame('hydrated:doc.pdf', $result->value);
     }
@@ -146,14 +185,15 @@ class UploaderColumnHydratorTest extends TestCase
             'upload|withMedia' => FakeSettingsAlternateUploader::class,
         ]));
 
-        $entry = new FakeSettingEntry(['value' => 'x.png']);
-
-        UploaderColumnHydrator::hydrate($entry, [
+        $entry  = new FakeSettingEntry(['value' => 'x.png']);
+        $column = [
             'name'      => 'value',
             'type'      => 'upload',
             'withFiles' => ['disk' => 'a'],
             'withMedia' => ['disk' => 'b'],
-        ]);
+        ];
+
+        UploaderColumnHydrator::hydrate($entry, $column);
 
         $this->assertCount(1, FakeSettingsUploader::$calls);
         $this->assertCount(0, FakeSettingsAlternateUploader::$calls);
@@ -171,8 +211,6 @@ class FakeSettingEntry extends Model
 
 class FakeUploadersRepository
 {
-    public static array $calls = [];
-
     public function __construct(private array $map = []) {}
 
     public function hasUploadFor($type, $macro): bool
@@ -196,7 +234,27 @@ class FakeSettingsUploader
     {
         self::$calls[] = compact('crudObject', 'uploadDefinition');
 
-        return new self($crudObject, $uploadDefinition);
+        return new static($crudObject, $uploadDefinition);
+    }
+
+    public function getDisk(): string
+    {
+        return $this->uploadDefinition['disk'] ?? 'public';
+    }
+
+    public function getPath(): string
+    {
+        return $this->uploadDefinition['path'] ?? '';
+    }
+
+    public function useTemporaryUrl(): bool
+    {
+        return false;
+    }
+
+    public function getExpirationTimeInMinutes(): int
+    {
+        return 1;
     }
 
     public function retrieveUploadedFiles(Model $entry): Model
@@ -223,5 +281,23 @@ class FakeSettingsAlternateUploader extends FakeSettingsUploader
         $entry->value = 'alt:'.$entry->value;
 
         return $entry;
+    }
+}
+
+class FakeTemporaryUrlUploader extends FakeSettingsUploader
+{
+    public function useTemporaryUrl(): bool
+    {
+        return true;
+    }
+
+    public function getExpirationTimeInMinutes(): int
+    {
+        return 15;
+    }
+
+    public function getDisk(): string
+    {
+        return 'private';
     }
 }


### PR DESCRIPTION
The datetime column was ignoring the format option because the list view was rendering setting values as plain text, regardless of the field type. This PR makes the value column actually respect the field definition.

What changed:

- New setting_value column that dispatches each row to the correct Backpack column view based on its field type (so datetime fields render as dates, checkbox as booleans, upload as images, etc.).
- New optional column DB field on the settings table, for cases where you want the display to differ from the edit form (e.g. add a prefix/suffix, use a different column type).
- A `FieldToColumnResolver` that translates a field definition into a column definition. Blacklists form-only keys (validation, attributes, view_namespace, ...) and lets everything else through, so new column types in future Backpack releases work without changes here.
- An `UploaderColumnHydrator` so withFiles / withMedia columns resolve stored paths to URLs per-row (can't use the macro's global retrieved event here — every Setting row shares the same model + value attribute, last uploader would win).


BC:
Off by default. Set `auto_resolve_columns => true` in the published config to opt in. Existing installs see no change until they publish the new migration and flip the flag. Planning to default it to true in the next major.

Tests: 31 new tests covering the resolver and the hydrator.